### PR TITLE
fix(pyaqueduct): Rename Aqueductpy to Pyaqueduct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project uses the following main software stack and technologies:
 - [Usage](#usage)
 - [Installation](#installation)
   * [Developers Setup Guide](#developers-setup-guide)
-  * [AqueductPy](#aqueductpy)
+  * [PyAqueduct](#pyaqueduct)
   * [Database Migration Guide](#database-migration-guide)
     + [Steps](#steps)
 - [Contributing](#contributing)
@@ -25,7 +25,7 @@ Aqueduct contains data management tools that augment a lab’s existing data sto
 
 This functionality is facilitated through 2 components:
 - [aqueductcore](/aqueductcore) is the server software that hosts the main application, and web interface and handles data storage.
-- [aqueductpy](/aqueductpy) is our Python Library which allows easy creation of experiments and upload of data and metadata for them.
+- [pyaqueduct](/pyaqueduct) is our Python Library which allows easy creation of experiments and upload of data and metadata for them.
   
 
 ## Installation
@@ -101,12 +101,12 @@ bash scripts/install_packages.sh
 
 After executing the script, proceed with the instructions from Step 3.
     
-### AqueductPy
+### PyAqueduct
 
-Although [AqueductPy](/aqueductPy) ---the Python Library--- is a separate project, you need to have that installed to pipe your experiment data in the system, as the GUI doesn't support experiment data upload but will do soon. You can find more information about how to use it [here](https://black-sand-0b0e2a903.3.azurestaticapps.net/main/getting-started) in the docs.
+Although [PyAqueduct](https://github.com/AqueductHub/pyaqueduct) ---the Python Library--- is a separate project, you need to have that installed to pipe your experiment data in the system, as the GUI doesn't support experiment data upload but will do soon. You can find more information about how to use it [here](https://black-sand-0b0e2a903.3.azurestaticapps.net/main/getting-started) in the docs.
 
 ```bash
-pip install AqueductPy
+pip install pyaqueduct
 ```
 
 ### Database Migration Guide

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
-# Aqueductpy Application Programming Interface (API) Tutorial
+# PyAqueduct Application Programming Interface (API) Tutorial
 
-In this tutorial, the API of Aqueductpy is introduced by working on a sample experiment. The sample experiment generates some results in the form of different files such as CSV, JSON, HDF5, and image files. Each execution of the experiment generates new set of files and therefore, is treated as a new experiment run.
+In this tutorial, the API of PyAqueduct is introduced by working on a sample experiment. The sample experiment generates some results in the form of different files such as CSV, JSON, HDF5, and image files. Each execution of the experiment generates new set of files and therefore, is treated as a new experiment run.
 
 ## Experiment: analysis of projectile motion 
 
@@ -108,7 +108,7 @@ print("Simulation and data processing completed.")
 
 
 ```python
-from aqueductpy import API
+from pyaqueduct import API
 
 api = API("[AQUEDUCT_SERVER_URL_PLACE_HOLDER]", timeout=1)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@ On this page we provide instructions for two ways to set up Aqueduct:
 - [Installing from source](#installing-from-source)
 
 ## Using Production Docker Images
-For the ease of deployment in production, Aqueduct releases a production-ready container image. The docker images are available through Dockerhub.
+For the ease of deployment in production, Aqueduct is released as a production-ready container image. The docker image is available through Dockerhub, [`aqueducthub/aqueductcore`](https://hub.docker.com/r/aqueducthub/aqueductcore).
 
 This example Docker compose file shows how you can use the Docker images:
 
@@ -16,7 +16,7 @@ This example Docker compose file shows how you can use the Docker images:
 version: '3'
 services:
   aqueduct:
-    image: aqueductcore/release:latest
+    image: aqueducthub/aqueductcore:latest
     restart: always
     depends_on:
       - postgres

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -60,12 +60,12 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [aqueductpy]
+          paths: [pyaqueduct]
 
 nav:
   - "index.md"
   - "setup.md"
   - "getting-started.md"
-  - "Python Client": "https://aqueducthub.github.io/aqueductpy/"
+  - "Python Client": "https://aqueducthub.github.io/pyaqueduct/"
 
 copyright: Copyright &copy; 2023 - 2024 Riverlane Ltd.


### PR DESCRIPTION
In this PR, the change of name for the Python client is applied in the docs. Also, the docker image name is updated.