### PR TITLE
fix(files): Add validation for file names to the files API

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1874,6 +1874,21 @@ files = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.2.0"
+description = "pathvalidate is a Python library to sanitize/validate a string such as filenames/file-paths/etc."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathvalidate-3.2.0-py3-none-any.whl", hash = "sha256:cc593caa6299b22b37f228148257997e2fa850eea2daf7e4cc9205cef6908dee"},
+    {file = "pathvalidate-3.2.0.tar.gz", hash = "sha256:5e8378cf6712bff67fbe7a8307d99fa8c1a0cb28aa477056f8fc374f0dff24ad"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=2.4)", "sphinx-rtd-theme (>=1.2.2)", "urllib3 (<2)"]
+test = ["Faker (>=1.0.8)", "allpairspy (>=2)", "click (>=6.2)", "pytest (>=6.0.1)", "pytest-discord (>=0.1.4)", "pytest-md-report (>=0.4.1)"]
+
+[[package]]
 name = "pip-licenses"
 version = "4.3.4"
 description = "Dump the software license list of Python packages installed with pip."
@@ -3672,4 +3687,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8,< 3.12"
-content-hash = "612f7e1e362af865a31425a243e8e0fb3fc9ee36582fd1aa99616ebeee36ab32"
+content-hash = "23e90553cd4e38a9bb7725e15f646660d6272e69172464e87a4512212ddd088d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ aiofiles = "^23.2"
 streaming-form-data = "^1.13"
 gunicorn = "^21.2"
 pip-licenses = "^4.3"
+pathvalidate = "^3.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,11 @@ authors = ["Aqueduct Team <aqueduct@riverlane.com>"]
 license = "MIT"
 readme = "README.md"
 
+
+exclude = [
+    "aqueductcore/frontend"
+]
+
 [tool.poetry.dependencies]
 python = ">= 3.8,< 3.12"
 grpcio = "^1.57"


### PR DESCRIPTION
This PR adds the validation step for the file name input to the file APIs. Unit tests are in place to cover the changes. A small addition is excluding frontend source code (uncompiled raw) from the Python package build, configured in the toml file.