### PR TITLE
feat(security)!: Permission based access to the API via authentication tokens

### DIFF
--- a/aqueductcore/backend/context.py
+++ b/aqueductcore/backend/context.py
@@ -1,22 +1,75 @@
 """Server context management module."""
 
-from typing import AsyncGenerator
+from enum import Enum
+from typing import AsyncGenerator, List
+from uuid import UUID
 
+from fastapi import Depends, HTTPException, status
+from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.fastapi import BaseContext
+from typing_extensions import Annotated
 
 from aqueductcore.backend.session import get_session
+
+get_bearer_token = HTTPBearer(auto_error=False)
+
+
+class ExperimentScope(str, Enum):
+    """Experiment scopes enumerator."""
+
+    VIEW_OWN = "experiment::view::own"
+    VIEW_ALL = "experiment::view::all"
+    EDIT_OWN = "experiment::edit::own"
+    EDIT_ALL = "experiment::edit::all"
+    DELETE_OWN = "experiment::delete::own"
+    DELETE_ALL = "experiment::delete::all"
+    CREATE_OWN = "experiment::create::own"
+
+
+class UserInfo(BaseModel):
+    """User information and security scopes (permissions)."""
+
+    user_id: UUID
+    scopes: List[str] = []
 
 
 class ServerContext(BaseContext):
     """Server context class."""
 
-    def __init__(self, db_session: AsyncSession):
+    def __init__(self, db_session: AsyncSession, user_info: UserInfo):
         super().__init__()
         self.db_session = db_session
+        self.user_info = user_info
 
 
-async def context_dependency() -> AsyncGenerator[ServerContext, None]:
+async def get_current_user(
+    token: Annotated[HTTPAuthorizationCredentials, Depends(get_bearer_token)],
+) -> UserInfo:
+    """Get the current user based on the provided authentication token."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.get_unverified_claims(token.credentials)
+        user_id: str = str(payload.get("sub"))
+        if user_id is None:
+            raise credentials_exception
+        token_scopes = payload.get("scopes", [])
+        token_data = UserInfo(scopes=token_scopes, user_id=UUID(user_id))
+    except JWTError as exc:
+        raise credentials_exception from exc
+
+    return token_data
+
+
+async def context_dependency(
+    user_info: Annotated[UserInfo, Depends(get_current_user)]
+) -> AsyncGenerator[ServerContext, None]:
     """Asynchronous dependency generator for server context."""
     async with get_session() as db_session:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=user_info)

--- a/aqueductcore/backend/context.py
+++ b/aqueductcore/backend/context.py
@@ -1,7 +1,7 @@
 """Server context management module."""
 
 from enum import Enum
-from typing import AsyncGenerator, List
+from typing import AsyncGenerator, Set
 from uuid import UUID
 
 from fastapi import Depends
@@ -13,23 +13,23 @@ from typing_extensions import Annotated
 from aqueductcore.backend.session import get_session
 
 
-class ExperimentScope(str, Enum):
+class UserScope(str, Enum):
     """Experiment scopes enumerator."""
 
-    VIEW_OWN = "experiment::view::own"
-    VIEW_ALL = "experiment::view::all"
-    EDIT_OWN = "experiment::edit::own"
-    EDIT_ALL = "experiment::edit::all"
-    DELETE_OWN = "experiment::delete::own"
-    DELETE_ALL = "experiment::delete::all"
-    CREATE_OWN = "experiment::create::own"
+    EXPERIMENT_VIEW_OWN = "experiment::view::own"
+    EXPERIMENT_VIEW_ALL = "experiment::view::all"
+    EXPERIMENT_EDIT_OWN = "experiment::edit::own"
+    EXPERIMENT_EDIT_ALL = "experiment::edit::all"
+    EXPERIMENT_DELETE_OWN = "experiment::delete::own"
+    EXPERIMENT_DELETE_ALL = "experiment::delete::all"
+    EXPERIMENT_CREATE_OWN = "experiment::create::own"
 
 
 class UserInfo(BaseModel):
     """User information and security scopes (permissions)."""
 
     user_id: UUID
-    scopes: List[str] = []
+    scopes: Set[UserScope]
 
 
 class ServerContext(BaseContext):
@@ -43,7 +43,7 @@ class ServerContext(BaseContext):
 
 async def get_current_user() -> UserInfo:
     """Get the current user based on the provided authentication token."""
-    token_data = UserInfo(scopes=[scope.value for scope in ExperimentScope], user_id=UUID(int=0))
+    token_data = UserInfo(scopes=set(UserScope), user_id=UUID(int=0))
 
     return token_data
 

--- a/aqueductcore/backend/errors.py
+++ b/aqueductcore/backend/errors.py
@@ -15,6 +15,10 @@ class ECSValidationError(ECSDBError):
     """Exception raised when there is a validation error"""
 
 
+class ECSPermission(ECSDBError):
+    """Exception raised when there is a permission error"""
+
+
 class ECSDBExperimentNonExisting(ECSError):
     """Exception raised when there is no experiment in the DB with the specified details."""
 

--- a/aqueductcore/backend/models/experiment.py
+++ b/aqueductcore/backend/models/experiment.py
@@ -30,6 +30,7 @@ class ExperimentBase(AQDModel):
     """Base model for Experiment"""
 
     id: UUID
+    user_id: UUID
     title: str
     description: Optional[str] = None
 

--- a/aqueductcore/backend/models/orm.py
+++ b/aqueductcore/backend/models/orm.py
@@ -28,6 +28,7 @@ class Experiment(Base):
     __tablename__ = "experiment"
 
     id = mapped_column(Uuid, primary_key=True)
+    user_id = mapped_column(Uuid, nullable=False)
     title: Mapped[str]
     description: Mapped[Optional[str]] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(

--- a/aqueductcore/backend/routers/files.py
+++ b/aqueductcore/backend/routers/files.py
@@ -37,7 +37,9 @@ async def download_experiment_file(
     try:
         pathvalidate.validate_filename(file_name)
         # check if experiment exists with the specified ID, otherwise raises an exception.
-        await get_experiment_by_uuid(db_session=context.db_session, experiment_id=experiment_id)
+        await get_experiment_by_uuid(
+            user_info=context.user_info, db_session=context.db_session, experiment_id=experiment_id
+        )
         experiment_dir = build_experiment_dir_absolute_path(
             str(settings.experiments_dir_path), experiment_id
         )
@@ -111,7 +113,9 @@ async def upload_experiment_file(
     try:
         pathvalidate.validate_filename(file_name)
         # check if experiment exists with the specified ID, otherwise raises an exception.
-        await get_experiment_by_uuid(db_session=context.db_session, experiment_id=experiment_id)
+        await get_experiment_by_uuid(
+            user_info=context.user_info, db_session=context.db_session, experiment_id=experiment_id
+        )
         experiment_dir = build_experiment_dir_absolute_path(
             str(settings.experiments_dir_path), experiment_id
         )

--- a/aqueductcore/backend/routers/graphql/mutations/experiment_mutations.py
+++ b/aqueductcore/backend/routers/graphql/mutations/experiment_mutations.py
@@ -2,8 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
+from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.routers.graphql.inputs import (
     ExperimentCreateInput,
     ExperimentTagInput,
@@ -15,12 +14,13 @@ from aqueductcore.backend.services import experiment as experiment_service
 
 
 async def create_experiment(
-    db_session: AsyncSession, create_experiment_input: ExperimentCreateInput
+    context: ServerContext, create_experiment_input: ExperimentCreateInput
 ) -> ExperimentData:
     """Create experiment mutation"""
 
     experiment = await experiment_service.create_experiment(
-        db_session=db_session,
+        user_info=context.user_info,
+        db_session=context.db_session,
         title=create_experiment_input.title,
         description=create_experiment_input.description,
         tags=create_experiment_input.tags,
@@ -29,12 +29,13 @@ async def create_experiment(
 
 
 async def update_experiment(
-    db_session: AsyncSession, experiment_id: UUID, experiment_update_input: ExperimentUpdateInput
+    context: ServerContext, experiment_id: UUID, experiment_update_input: ExperimentUpdateInput
 ) -> ExperimentData:
     """Update experiment mutation"""
 
     experiment = await experiment_service.update_experiment(
-        db_session=db_session,
+        user_info=context.user_info,
+        db_session=context.db_session,
         experiment_id=experiment_id,
         title=experiment_update_input.title,
         description=experiment_update_input.description,
@@ -43,12 +44,13 @@ async def update_experiment(
 
 
 async def add_tag_to_experiment(
-    db_session: AsyncSession, experiment_tag_input: ExperimentTagInput
+    context: ServerContext, experiment_tag_input: ExperimentTagInput
 ) -> ExperimentData:
     """Add tag to experiment mutation"""
 
     experiment = await experiment_service.add_tag_to_experiment(
-        db_session=db_session,
+        user_info=context.user_info,
+        db_session=context.db_session,
         experiment_id=experiment_tag_input.experiment_id,
         tag=experiment_tag_input.tag,
     )
@@ -56,12 +58,13 @@ async def add_tag_to_experiment(
 
 
 async def remove_tag_from_experiment(
-    db_session: AsyncSession, experiment_tag_input: ExperimentTagInput
+    context: ServerContext, experiment_tag_input: ExperimentTagInput
 ) -> ExperimentData:
     """Remove tag from experiment mutation"""
 
     experiment = await experiment_service.remove_tag_from_experiment(
-        db_session=db_session,
+        user_info=context.user_info,
+        db_session=context.db_session,
         experiment_id=experiment_tag_input.experiment_id,
         tag=experiment_tag_input.tag,
     )

--- a/aqueductcore/backend/routers/graphql/mutations_schema.py
+++ b/aqueductcore/backend/routers/graphql/mutations_schema.py
@@ -33,7 +33,7 @@ class Mutation:
 
         context = cast(ServerContext, info.context)
         experiment = await create_experiment(
-            db_session=context.db_session, create_experiment_input=create_experiment_input
+            context=context, create_experiment_input=create_experiment_input
         )
         return experiment
 
@@ -45,7 +45,7 @@ class Mutation:
 
         context = cast(ServerContext, info.context)
         experiment = await update_experiment(
-            db_session=context.db_session,
+            context=context,
             experiment_id=experiment_id,
             experiment_update_input=experiment_update_input,
         )
@@ -59,7 +59,7 @@ class Mutation:
 
         context = cast(ServerContext, info.context)
         experiment = await add_tag_to_experiment(
-            db_session=context.db_session, experiment_tag_input=experiment_tag_input
+            context=context, experiment_tag_input=experiment_tag_input
         )
         return experiment
 
@@ -70,6 +70,6 @@ class Mutation:
         """Mutation to remove tag from experiment"""
         context = cast(ServerContext, info.context)
         experiment = await remove_tag_from_experiment(
-            db_session=context.db_session, experiment_tag_input=experiment_tag_input
+            context=context, experiment_tag_input=experiment_tag_input
         )
         return experiment

--- a/aqueductcore/backend/routers/graphql/query_schema.py
+++ b/aqueductcore/backend/routers/graphql/query_schema.py
@@ -59,7 +59,7 @@ class Query:
         """Resolver for the experiments."""
         context = cast(ServerContext, info.context)
         experiments = await get_expriments(
-            db_session=context.db_session, offset=offset, limit=limit, filters=filters
+            context=context, offset=offset, limit=limit, filters=filters
         )
         return experiments
 
@@ -70,7 +70,7 @@ class Query:
         """Resolver for a single experiment."""
         context = cast(ServerContext, info.context)
         experiment = await get_experiment(
-            db_session=context.db_session, experiment_identifier=experiment_identifier
+            context=context, experiment_identifier=experiment_identifier
         )
         return experiment
 
@@ -84,7 +84,5 @@ class Query:
     ) -> Tags:
         """Resolver for the tags."""
         context = cast(ServerContext, info.context)
-        tags = await get_tags(
-            db_session=context.db_session, limit=limit, offset=offset, filters=filters
-        )
+        tags = await get_tags(context=context, limit=limit, offset=offset, filters=filters)
         return tags

--- a/aqueductcore/backend/routers/graphql/resolvers/tags_resolver.py
+++ b/aqueductcore/backend/routers/graphql/resolvers/tags_resolver.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
+from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.errors import ECSValidationError
 from aqueductcore.backend.routers.graphql.types import Tags
 from aqueductcore.backend.services.experiment import get_all_tags
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 
 
 async def get_tags(
-    db_session: AsyncSession,
+    context: ServerContext,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
     filters: Optional[TagsFilters] = None,
@@ -33,7 +32,11 @@ async def get_tags(
 
     tags = [
         item.name
-        for item in await get_all_tags(db_session=db_session, include_dangling=include_dangling)
+        for item in await get_all_tags(
+            user_info=context.user_info,
+            db_session=context.db_session,
+            include_dangling=include_dangling,
+        )
     ]
     tags_count = len(tags)
 

--- a/aqueductcore/backend/routers/graphql/types.py
+++ b/aqueductcore/backend/routers/graphql/types.py
@@ -21,6 +21,7 @@ async def get_files(info: Info, root: ExperimentData) -> List[ExperimentFile]:
     context = cast(ServerContext, info.context)
     files = await get_experiment_files(
         user_info=context.user_info,
+        db_session=context.db_session,
         experiments_root_dir=str(settings.experiments_dir_path),
         experiment_id=experiment_id,
     )

--- a/aqueductcore/backend/routers/graphql/types.py
+++ b/aqueductcore/backend/routers/graphql/types.py
@@ -3,22 +3,26 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, cast
 from uuid import UUID
 
 import strawberry
+from strawberry.types import Info
 
+from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.services.experiment import get_experiment_files
 from aqueductcore.backend.settings import settings
 
 
-async def get_files(root: ExperimentData) -> List[ExperimentFile]:
+async def get_files(info: Info, root: ExperimentData) -> List[ExperimentFile]:
     """Resolve experiment files."""
     experiment_id = root.id
     result: List[ExperimentFile] = []
-
+    context = cast(ServerContext, info.context)
     files = await get_experiment_files(
-        experiments_root_dir=str(settings.experiments_dir_path), experiment_id=experiment_id
+        user_info=context.user_info,
+        experiments_root_dir=str(settings.experiments_dir_path),
+        experiment_id=experiment_id,
     )
     for name, modified_time in files:
         result.append(

--- a/aqueductcore/backend/services/utils.py
+++ b/aqueductcore/backend/services/utils.py
@@ -23,6 +23,7 @@ async def experiment_orm_to_model(value: orm.Experiment) -> ExperimentRead:
         alias=value.alias,
         id=value.id,
         title=value.title,
+        user_id=value.user_id,
         tags=[tag_orm_to_model(tag) for tag in value.tags],
     )
 
@@ -39,7 +40,11 @@ def tag_orm_to_model(value: orm.Tag) -> TagRead:
 def experiment_model_to_orm(value: ExperimentCreate) -> orm.Experiment:
     """Convert Pydantic Experiment to ORM Experiment."""
     experiment = orm.Experiment(
-        id=value.id, title=value.title, description=value.description, alias=value.alias
+        user_id=value.user_id,
+        id=value.id,
+        title=value.title,
+        description=value.description,
+        alias=value.alias,
     )
     experiment.tags.extend([tag_model_to_orm(item) for item in value.tags])
 
@@ -53,7 +58,7 @@ def tag_model_to_orm(value: TagCreate) -> orm.Tag:
     return tag
 
 
-def generate_id_and_alias(experiment_index: int) -> Tuple[UUID, str]:
+def generate_experiment_id_and_alias(experiment_index: int) -> Tuple[UUID, str]:
     """Generate uuid and alias for experiment"""
     current_date = datetime.today().strftime("%Y%m%d")
     experiment_id = uuid4()

--- a/tests/unittests/initial_data.py
+++ b/tests/unittests/initial_data.py
@@ -1,10 +1,12 @@
 from datetime import datetime
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from aqueductcore.backend.models.experiment import ExperimentCreate, TagCreate
 
+user_id = uuid4()
 experiment_data = [
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("b7038e5a-c93d-4cac-8d3d-b5a95ead0963"),
         title="Entangling Possibilities: Quantum Computing Explorations",
         description="Description for entangling possibilities: quantum computing explorations experiment",
@@ -16,6 +18,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-1",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("94d7d1a5-0840-481c-8f46-d9873f5fafa4"),
         title="Shifting Realities: Quantum Computing Challenges",
         description="Description for shifting realities: quantum computing challenges experiment",
@@ -23,6 +26,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-2",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("852b81bb-ced4-4c8d-8176-9c7184206638"),
         title="Beyond Bits: Quantum Computing Frontier",
         description="Description for beyond bits: quantum computing frontier experiment",
@@ -30,6 +34,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-3",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("763d3911-18ec-471d-a5ab-ff87c45dbc53"),
         title="Quantum Computing Odyssey: Unveiling New Realms",
         description="Description for quantum computing odyssey: unveiling new realms experiment",
@@ -37,6 +42,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-4",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("2d37f5c8-c318-4d2a-8f20-4d905adad3ff"),
         title="Harnessing Qubits: Quantum Computing Adventures",
         description="Description for harnessing qubits: quantum computing adventures experiment",
@@ -44,6 +50,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-5",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("65c5589b-e42a-48f5-b208-263221a04046"),
         title="Dancing with Superposition: Quantum Computing Feats",
         description="Description for dancing with superposition: quantum computing feats experiment",
@@ -51,6 +58,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-6",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("8018059d-f910-49ac-8bd3-892fc841cab0"),
         title="Quantum Leap: Pioneering Computing Frontiers",
         description="Description for quantum leap: pioneering computing frontiers experiment",
@@ -58,6 +66,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-7",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("877a14dd-124c-4c43-bcc2-2cf2ce9aa991"),
         title="Nanoworld Wonders: Quantum Computing Enigma",
         description="Description for nanoworld wonders: quantum computing enigma experiment",
@@ -68,6 +77,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-8",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("a299d4af-0d14-4436-98db-8fc20af3684d"),
         title="Spinning Qubits: Quantum Computing Quests",
         description="Description for spinning qubits: quantum computing quests experiment",
@@ -75,6 +85,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-9",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("4f4758b3-3594-4099-90dc-198b33b22cee"),
         title="Einstein's Legacy: Quantum Computing Journeys",
         description="Description for einstein's legacy: quantum computing journeys experiment",
@@ -82,6 +93,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-10",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("1adb18c4-3adf-40cf-bcc7-4b32d1d22be7"),
         title="Entangling Possibilities: Quantum Computing Explorations",
         description="Description for entangling possibilities: quantum computing explorations experiment",
@@ -89,6 +101,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-11",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("95def0bb-e9f2-4e3b-aab5-4c388746c69b"),
         title="Quantum Enigmas Unraveled: Computing Marvels",
         description="Description for quantum enigmas unraveled: computing marvels experiment",
@@ -96,6 +109,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-12",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("21e4e718-a228-44ed-9e3c-ebbf498de4fd"),
         title="Qubit Chronicles: Quantum Computing Escapades",
         description="Description for qubit chronicles: quantum computing escapades experiment",
@@ -103,6 +117,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-13",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("b2c8ab96-35b1-4b2b-a265-72c50a55eb70"),
         title="Quantum Horizons: Computing Beyond Imagination",
         description="Description for quantum horizons: computing beyond imagination experiment",
@@ -110,6 +125,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-14",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("8258681b-6e39-4582-a3c4-e50d5248ae2d"),
         title="Quantum Pioneers: Computing Challenges Ahead",
         description="Description for quantum pioneers: computing challenges ahead experiment",
@@ -117,6 +133,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-15",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("f313d64b-d86d-4612-8ef9-bc5db16fe411"),
         title="Journey to Quantum Supremacy: Computing Marvels",
         description="Description for journey to quantum supremacy: computing marvels experiment",
@@ -124,6 +141,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-16",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("d40a4f1d-3fdc-407a-907d-16fae3326b7e"),
         title="In the Quantum Lab: Computing Experiments",
         description="Description for in the quantum lab: computing experiments experiment",
@@ -131,6 +149,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-17",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("8aa0077a-4fe4-4108-a975-648d2a15ff46"),
         title="Breaking the Classical Barrier: Quantum Computing",
         description="Description for breaking the classical barrier: quantum computing experiment",
@@ -138,6 +157,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-18",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("fb7eeb96-31da-4bfe-9364-12e8e54eaae8"),
         title="Quantum Quest: Computing on the Edge",
         description="Description for quantum quest: computing on the edge experiment",
@@ -145,6 +165,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-19",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("deb25566-1d18-4d0f-9d8e-91a7045bf8da"),
         title="Taming Quantum Chaos: Computing Marvels",
         description="Description for taming quantum chaos: computing marvels experiment",
@@ -152,6 +173,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-20",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("fcfc2b77-4637-48b8-8cc3-7ce0348b3d60"),
         title="Dive into the Quantum Realm: Computing Odyssey",
         description="Description for dive into the quantum realm: computing odyssey experiment",
@@ -159,6 +181,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-21",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("6d5df827-8da2-4df4-b294-16718f905121"),
         title="Uncharted Quantum Territory: Computing Explorations",
         description="Description for uncharted quantum territory: computing explorations experiment",
@@ -166,6 +189,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-22",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("d60fcc1b-a8a0-4f0b-a5ae-3e120fe92c73"),
         title="Quantum Mechanics in Silicon: Computing Frontiers",
         description="Description for quantum mechanics in silicon: computing frontiers experiment",
@@ -173,6 +197,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-23",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("af7af6f0-49d6-4381-8485-e6a0092f4891"),
         title="Quantum Computing Riddles: Unveiling the Future",
         description="Description for quantum computing riddles: unveiling the future experiment",
@@ -180,6 +205,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-24",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("8ef9348e-c51f-4f56-9d3d-11926967cc2c"),
         title="Beyond Binary: Quantum Computing Wonders",
         description="Description for beyond binary: quantum computing wonders experiment",
@@ -187,6 +213,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-25",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("e839fdb5-6a6c-47e1-b327-385055eebbf7"),
         title="Quantum Voyage: Computing the Unseen",
         description="Description for quantum voyage: computing the unseen experiment",
@@ -194,6 +221,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-26",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("d2dfcb36-91f6-46fe-a9b4-99f20509908b"),
         title="Adventures in Quantum Computing: The Next Frontier",
         description="Description for adventures in quantum computing: the next frontier experiment",
@@ -201,6 +229,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-27",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("a9263fdb-3867-4adb-9354-3c1e7b870863"),
         title="Decoding Quantum Mysteries: Computing Marvels",
         description="Description for decoding quantum mysteries: computing marvels experiment",
@@ -208,6 +237,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-28",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("7dcad510-349d-4245-a8cb-7752b8a7e985"),
         title="Quantum Puzzles: Computing Beyond Limits",
         description="Description for quantum puzzles: computing beyond limits experiment",
@@ -215,6 +245,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-29",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("6df6d881-b5ca-4e75-9cc3-b12a9e888e49"),
         title="Riding the Quantum Wave: Computing Challenges",
         description="Description for riding the quantum wave: computing challenges experiment",
@@ -222,6 +253,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-30",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("0dffb19d-4a69-46bd-99d2-933435171bc7"),
         title="Quantum Expeditions: Computing Marvels",
         description="Description for quantum expeditions: computing marvels experiment",
@@ -229,6 +261,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-31",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("87e3b50d-7117-41d9-b2a1-18c145815e63"),
         title="Exploring Quantum Superposition: Computing Feats",
         description="Description for exploring quantum superposition: computing feats experiment",
@@ -236,6 +269,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-32",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("47250d33-051c-44f7-ae32-cb01bf9905c0"),
         title="Quantum Quandaries Unveiled: Computing Enigma",
         description="Description for quantum quandaries unveiled: computing enigma experiment",
@@ -243,6 +277,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-33",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("2f313090-4abd-4eac-b893-84d487ac395b"),
         title="Into the Quantum Void: Computing Odyssey",
         description="Description for into the quantum void: computing odyssey experiment",
@@ -250,6 +285,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-34",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("400ab061-2a59-406f-96bd-c331015a05f6"),
         title="Quantum Leap into Computing: Bold Experiments",
         description="Description for quantum leap into computing: bold experiments experiment",
@@ -257,6 +293,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-35",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("54d17d8f-fcc8-49ab-bc01-dc12ea6736db"),
         title="Quantum Computing Chronicles: Unveiling the Future",
         description="Description for quantum computing chronicles: unveiling the future experiment",
@@ -264,6 +301,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-36",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("e7df2b1d-fd13-40ba-8ce7-68002910c8b4"),
         title="Navigating Quantum Realms: Computing Quests",
         description="Description for navigating quantum realms: computing quests experiment",
@@ -271,6 +309,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-37",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("ee30df31-8855-4a59-8656-5a94dfe8490d"),
         title="Quantum Complexity Unraveled: Computing Marvels",
         description="Description for quantum complexity unraveled: computing marvels experiment",
@@ -278,6 +317,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-38",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("1430c8f2-b2a2-4ab4-9740-d68bdf75d0b3"),
         title="Quantum Computation Alchemy: Adventures Await",
         description="Description for quantum computation alchemy: adventures await experiment",
@@ -285,6 +325,7 @@ experiment_data = [
         alias=f"{datetime.now().strftime('%Y%m%d')}-39",
     ),
     ExperimentCreate(
+        user_id=user_id,
         id=UUID("53f8d93b-d4a5-4c20-8744-cda31659b436"),
         title="The Quantum Computing Revolution: Challenges Ahead",
         description="Description for the quantum computing revolution: challenges ahead experiment",

--- a/tests/unittests/test_experiment_services.py
+++ b/tests/unittests/test_experiment_services.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from aqueductcore.backend.context import UserInfo
+from aqueductcore.backend.context import UserInfo, UserScope
 from aqueductcore.backend.models.experiment import ExperimentCreate, TagCreate
 from aqueductcore.backend.services.experiment import (
     add_tag_to_experiment,
@@ -40,7 +40,7 @@ async def test_get_all_experiments(
     await db_session.commit()
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]), db_session=db_session
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)), db_session=db_session
     )
 
     assert len(experiments) == len(experiments_data)
@@ -68,7 +68,7 @@ async def test_get_all_experiments_limit_exceeded(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         order_by_creation_date=True,
     )
@@ -86,7 +86,7 @@ async def test_get_all_experiments_ordered_by_creation_date(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         order_by_creation_date=True,
     )
@@ -116,7 +116,9 @@ async def test_get_all_experiments_filtered_by_tag(
     await db_session.commit()
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]), db_session=db_session, tags=["tag1"]
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        db_session=db_session,
+        tags=["tag1"],
     )
 
     assert len(experiments) == 1
@@ -140,7 +142,7 @@ async def test_get_all_experiments_filtered_by_tag_ordered_by_creation_date(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         tags=["tag1"],
         order_by_creation_date=True,
@@ -167,7 +169,7 @@ async def test_get_experiment_by_uuid(
     await db_session.commit()
 
     experiment = await get_experiment_by_uuid(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
     )
@@ -193,7 +195,7 @@ async def test_get_experiment_by_alias(
     await db_session.commit()
 
     experiment = await get_experiment_by_alias(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         alias=experiments_data[0].alias,
     )
@@ -219,7 +221,7 @@ async def test_create_db_experiment_pre_existing_data(
     await db_session.commit()
 
     in_db_experiment = await create_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         title="Quantum Communication Protocols for Secure Networks",
         description="Design and evaluate quantum communication protocols to establish secure quantum networks, exploring the potential of quantum key distribution.",
@@ -250,7 +252,7 @@ async def test_create_db_experiment_empty_db(
     """Test create_db_experiment operation with empty database."""
 
     in_db_experiment = await create_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         title="Quantum Communication Protocols for Secure Networks",
         description="Design and evaluate quantum communication protocols to establish secure quantum networks, exploring the potential of quantum key distribution.",
@@ -287,7 +289,7 @@ async def test_update_db_experiment(
     await db_session.commit()
 
     in_db_experiment = await update_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         title="Quantum-enhanced Imaging for Biomedical Applications",
@@ -315,7 +317,7 @@ async def test_add_db_tag_to_experiment(
     await db_session.commit()
 
     in_db_experiment = await add_tag_to_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         tag="important",
@@ -339,7 +341,7 @@ async def test_remove_db_tag_from_experiment(
     await db_session.commit()
 
     in_db_experiment = await remove_tag_from_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         tag="tag1",
@@ -363,7 +365,9 @@ async def test_get_all_tags_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]), db_session=db_session, include_dangling=True
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        db_session=db_session,
+        include_dangling=True,
     )
     assert len(tags) == 3
     for idx, tag in enumerate(experiments_data[0].tags):
@@ -371,7 +375,7 @@ async def test_get_all_tags_dangling(
         assert tags[idx].name == tag.name
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         include_dangling=False,
     )
@@ -400,7 +404,9 @@ async def test_get_all_tags_mix_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]), db_session=db_session, include_dangling=True
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        db_session=db_session,
+        include_dangling=True,
     )
     assert len(tags) == 9
     assert set([item.key for item in tags]) == set(
@@ -411,7 +417,7 @@ async def test_get_all_tags_mix_dangling(
     )
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         include_dangling=False,
     )
@@ -437,7 +443,7 @@ async def test_get_all_tags_no_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=[]),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
         db_session=db_session,
         include_dangling=False,
     )
@@ -461,7 +467,7 @@ async def test_add_and_get_tags_for_experiment(
 
     for experiment in experiments_data:
         experiment_model = await get_experiment_by_uuid(
-            user_info=UserInfo(user_id=uuid4(), scopes=[]),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
             db_session=db_session,
             experiment_id=experiment.id,
         )
@@ -471,10 +477,21 @@ async def test_add_and_get_tags_for_experiment(
 
 
 @pytest.mark.asyncio
-async def test_get_experiment_files(temp_experiment_files: Dict[UUID, List[Tuple[str, datetime]]]):
+async def test_get_experiment_files(
+    db_session: AsyncSession,
+    experiments_data: List[ExperimentCreate],
+    temp_experiment_files: Dict[UUID, List[Tuple[str, datetime]]],
+):
+    for experiment in experiments_data:
+        db_experiment = experiment_model_to_orm(experiment)
+        db_session.add(db_experiment)
+
+    await db_session.commit()
+
     for key, value in temp_experiment_files.items():
         files = await get_experiment_files(
-            user_info=UserInfo(user_id=uuid4(), scopes=[]),
+            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            db_session=db_session,
             experiments_root_dir=str(settings.experiments_dir_path),
             experiment_id=key,
         )
@@ -493,7 +510,8 @@ async def test_get_experiment_files_empty(
 
     for experiment in experiments_data:
         files = await get_experiment_files(
-            user_info=UserInfo(user_id=uuid4(), scopes=[]),
+            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            db_session=db_session,
             experiments_root_dir=str(settings.experiments_dir_path),
             experiment_id=experiment.id,
         )

--- a/tests/unittests/test_files.py
+++ b/tests/unittests/test_files.py
@@ -11,7 +11,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from aqueductcore.backend.context import ServerContext, context_dependency
+from aqueductcore.backend.context import ServerContext, UserInfo, context_dependency
 from aqueductcore.backend.main import app
 from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.services.experiment import build_experiment_dir_absolute_path
@@ -61,7 +61,7 @@ async def test_file_download(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -86,7 +86,7 @@ async def test_nonexisting_file_download(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -137,7 +137,7 @@ async def test_file_upload_experiment_id(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -203,7 +203,7 @@ async def test_file_upload_max_body_size(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -239,7 +239,7 @@ async def test_file_upload_max_file_size(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -299,7 +299,7 @@ async def test_file_upload_non_existing_body(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -332,7 +332,7 @@ async def test_file_upload_invalid_filename(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session)
+        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 

--- a/tests/unittests/test_files.py
+++ b/tests/unittests/test_files.py
@@ -11,7 +11,12 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from aqueductcore.backend.context import ServerContext, UserInfo, context_dependency
+from aqueductcore.backend.context import (
+    ServerContext,
+    UserInfo,
+    UserScope,
+    context_dependency,
+)
 from aqueductcore.backend.main import app
 from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.services.experiment import build_experiment_dir_absolute_path
@@ -61,7 +66,9 @@ async def test_file_download(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -86,7 +93,9 @@ async def test_nonexisting_file_download(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -137,7 +146,9 @@ async def test_file_upload_experiment_id(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -203,7 +214,9 @@ async def test_file_upload_max_body_size(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -239,7 +252,9 @@ async def test_file_upload_max_file_size(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -299,7 +314,9 @@ async def test_file_upload_non_existing_body(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 
@@ -332,7 +349,9 @@ async def test_file_upload_invalid_filename(
     await db_session.commit()
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
-        yield ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+        yield ServerContext(
+            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
 

--- a/tests/unittests/test_graphql_mutations.py
+++ b/tests/unittests/test_graphql_mutations.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry import Schema
 
-from aqueductcore.backend.context import ServerContext, UserInfo
+from aqueductcore.backend.context import ServerContext, UserInfo, UserScope
 from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.routers.graphql.mutations_schema import Mutation
 from aqueductcore.backend.routers.graphql.query_schema import Query
@@ -225,7 +225,9 @@ async def test_create_experiment_invalid_title(
         await db_session.refresh(db_exerperiment)
 
     schema = Schema(query=Query, mutation=Mutation)
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(create_experiment_mutation_invalid_title, context_value=context)
 
     assert (
@@ -249,7 +251,9 @@ async def test_create_experiment_invalid_description(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(
         create_experiment_mutation_invalid_description, context_value=context
     )
@@ -275,7 +279,9 @@ async def test_create_experiment_invalid_tags(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(create_experiment_mutation_invalid_tags, context_value=context)
 
     assert resp.data is None
@@ -298,7 +304,9 @@ async def test_create_experiment_over_limit_tags(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(create_experiment_mutation_over_limit_tags, context_value=context)
 
     assert (
@@ -323,7 +331,9 @@ async def test_update_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(update_experiment_mutation, context_value=context)
 
     assert resp.errors is None
@@ -352,7 +362,9 @@ async def test_add_tag_to_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(add_tag_to_experiment_mutation, context_value=context)
 
     assert resp.errors is None
@@ -378,7 +390,9 @@ async def test_remove_tag_from_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(remove_tag_from_experiment_mutation, context_value=context)
 
     assert resp.errors is None

--- a/tests/unittests/test_graphql_mutations.py
+++ b/tests/unittests/test_graphql_mutations.py
@@ -1,12 +1,13 @@
 # pylint: skip-file
 # mypy: ignore-errors
 from typing import List
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry import Schema
 
-from aqueductcore.backend.context import ServerContext
+from aqueductcore.backend.context import ServerContext, UserInfo
 from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.routers.graphql.mutations_schema import Mutation
 from aqueductcore.backend.routers.graphql.query_schema import Query
@@ -224,8 +225,7 @@ async def test_create_experiment_invalid_title(
         await db_session.refresh(db_exerperiment)
 
     schema = Schema(query=Query, mutation=Mutation)
-
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(create_experiment_mutation_invalid_title, context_value=context)
 
     assert (
@@ -249,7 +249,7 @@ async def test_create_experiment_invalid_description(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(
         create_experiment_mutation_invalid_description, context_value=context
     )
@@ -275,7 +275,7 @@ async def test_create_experiment_invalid_tags(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(create_experiment_mutation_invalid_tags, context_value=context)
 
     assert resp.data is None
@@ -298,7 +298,7 @@ async def test_create_experiment_over_limit_tags(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(create_experiment_mutation_over_limit_tags, context_value=context)
 
     assert (
@@ -323,7 +323,7 @@ async def test_update_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(update_experiment_mutation, context_value=context)
 
     assert resp.errors is None
@@ -352,7 +352,7 @@ async def test_add_tag_to_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(add_tag_to_experiment_mutation, context_value=context)
 
     assert resp.errors is None
@@ -378,7 +378,7 @@ async def test_remove_tag_from_experiment(
 
     schema = Schema(query=Query, mutation=Mutation)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(remove_tag_from_experiment_mutation, context_value=context)
 
     assert resp.errors is None

--- a/tests/unittests/test_graphql_queries.py
+++ b/tests/unittests/test_graphql_queries.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry import Schema
 
-from aqueductcore.backend.context import ServerContext, UserInfo
+from aqueductcore.backend.context import ServerContext, UserInfo, UserScope
 from aqueductcore.backend.models.experiment import (
     ExperimentCreate,
     ExperimentRead,
@@ -307,7 +307,9 @@ async def test_query_all_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(all_experiments_query, context_value=context)
 
     assert resp.errors is None
@@ -345,7 +347,9 @@ async def test_query_all_experiments_invalid_limit(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(all_experiments_invalid_limit_query, context_value=context)
 
     assert (
@@ -370,7 +374,9 @@ async def test_query_all_experiments_title_filter(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
     assert (
@@ -398,7 +404,9 @@ async def test_query_all_experiments_max_tags_filter(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
     assert (
@@ -423,7 +431,9 @@ async def test_query_single_experiment(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
 
     # check with UUID
     resp = await schema.execute(
@@ -476,7 +486,9 @@ async def test_filter_by_tags_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(filter_by_tag_query, context_value=context)
 
     assert resp.errors is None
@@ -498,7 +510,9 @@ async def test_filter_by_title_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(filter_by_title_query, context_value=context)
 
     assert resp.errors is None
@@ -526,7 +540,9 @@ async def test_query_all_tags_all(
     schema = Schema(query=Query)
 
     # enable dangling tags
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(
         all_tags_query,
         context_value=context,
@@ -579,7 +595,9 @@ async def test_query_all_tags_no_dangling(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(
         all_tags_query,
         context_value=context,
@@ -614,7 +632,9 @@ async def test_query_over_limit_all_tags(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(tags_pagination_over_limit_query, context_value=context)
     assert resp.errors[0].message == f"Maximum allowed limit for tags is {MAX_TAGS_PER_REQUEST}"
 
@@ -631,7 +651,9 @@ async def test_query_pagination_tags(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
+    context = ServerContext(
+        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+    )
     resp = await schema.execute(tags_pagination_query, context_value=context)
 
     tags = await get_all_tags(user_info=context.user_info, db_session=context.db_session)

--- a/tests/unittests/test_graphql_queries.py
+++ b/tests/unittests/test_graphql_queries.py
@@ -2,13 +2,13 @@
 # mypy: ignore-errors
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry import Schema
 
-from aqueductcore.backend.context import ServerContext
+from aqueductcore.backend.context import ServerContext, UserInfo
 from aqueductcore.backend.models.experiment import (
     ExperimentCreate,
     ExperimentRead,
@@ -307,7 +307,7 @@ async def test_query_all_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(all_experiments_query, context_value=context)
 
     assert resp.errors is None
@@ -345,7 +345,7 @@ async def test_query_all_experiments_invalid_limit(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(all_experiments_invalid_limit_query, context_value=context)
 
     assert (
@@ -370,7 +370,7 @@ async def test_query_all_experiments_title_filter(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
     assert (
@@ -398,7 +398,7 @@ async def test_query_all_experiments_max_tags_filter(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
     assert (
@@ -423,7 +423,7 @@ async def test_query_single_experiment(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
 
     # check with UUID
     resp = await schema.execute(
@@ -476,7 +476,7 @@ async def test_filter_by_tags_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(filter_by_tag_query, context_value=context)
 
     assert resp.errors is None
@@ -498,7 +498,7 @@ async def test_filter_by_title_experiments(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(filter_by_title_query, context_value=context)
 
     assert resp.errors is None
@@ -526,14 +526,16 @@ async def test_query_all_tags_all(
     schema = Schema(query=Query)
 
     # enable dangling tags
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(
         all_tags_query,
         context_value=context,
         variable_values={"dangling": True},
     )
 
-    tags = await get_all_tags(db_session, include_dangling=True)
+    tags = await get_all_tags(
+        user_info=context.user_info, db_session=context.db_session, include_dangling=True
+    )
 
     assert resp.errors is None
     assert resp.data is not None
@@ -551,7 +553,9 @@ async def test_query_all_tags_all(
         variable_values={"dangling": False},
     )
 
-    tags = await get_all_tags(db_session, include_dangling=False)
+    tags = await get_all_tags(
+        user_info=context.user_info, db_session=context.db_session, include_dangling=False
+    )
 
     assert resp.errors is None
     assert resp.data is not None
@@ -575,14 +579,14 @@ async def test_query_all_tags_no_dangling(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(
         all_tags_query,
         context_value=context,
         variable_values={"dangling": False},
     )
 
-    tags = await get_all_tags(db_session)
+    tags = await get_all_tags(user_info=context.user_info, db_session=context.db_session)
 
     assert resp.errors is None
     assert resp.data is not None
@@ -610,7 +614,7 @@ async def test_query_over_limit_all_tags(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(tags_pagination_over_limit_query, context_value=context)
     assert resp.errors[0].message == f"Maximum allowed limit for tags is {MAX_TAGS_PER_REQUEST}"
 
@@ -627,10 +631,10 @@ async def test_query_pagination_tags(
 
     schema = Schema(query=Query)
 
-    context = ServerContext(db_session=db_session)
+    context = ServerContext(db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=[]))
     resp = await schema.execute(tags_pagination_query, context_value=context)
 
-    tags = await get_all_tags(db_session)
+    tags = await get_all_tags(user_info=context.user_info, db_session=context.db_session)
 
     assert resp.errors is None
     assert resp.data is not None


### PR DESCRIPTION
This PR adds permissions processing retrieved from the tokens in the service layer. The dependency injection system of FastAPI is used to propagate the scopes of the users down to the service layer to implement the business logic of permission-based access for the single user. In the core version, the token is not validated, however, in the pro version, I have implemented the required functionality for the tokens and users.