### PR TITLE
feat(user): Add `UserInfo` node to the GraphQL endpoint to return username and scopes.

### DIFF
--- a/aqueductcore/backend/context.py
+++ b/aqueductcore/backend/context.py
@@ -4,13 +4,12 @@ from enum import Enum
 from typing import AsyncGenerator, Set
 from uuid import UUID
 
+from aqueductcore.backend.session import get_session
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.fastapi import BaseContext
 from typing_extensions import Annotated
-
-from aqueductcore.backend.session import get_session
 
 
 class UserScope(str, Enum):
@@ -29,6 +28,7 @@ class UserInfo(BaseModel):
     """User information and security scopes (permissions)."""
 
     user_id: UUID
+    username: str
     scopes: Set[UserScope]
 
 
@@ -43,7 +43,7 @@ class ServerContext(BaseContext):
 
 async def get_current_user() -> UserInfo:
     """Get the current user based on the provided authentication token."""
-    token_data = UserInfo(scopes=set(UserScope), user_id=UUID(int=0))
+    token_data = UserInfo(scopes=set(UserScope), user_id=UUID(int=0), username="admin")
 
     return token_data
 

--- a/aqueductcore/backend/context.py
+++ b/aqueductcore/backend/context.py
@@ -4,12 +4,13 @@ from enum import Enum
 from typing import AsyncGenerator, Set
 from uuid import UUID
 
-from aqueductcore.backend.session import get_session
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.fastapi import BaseContext
 from typing_extensions import Annotated
+
+from aqueductcore.backend.session import get_session
 
 
 class UserScope(str, Enum):

--- a/aqueductcore/backend/routers/graphql/query_schema.py
+++ b/aqueductcore/backend/routers/graphql/query_schema.py
@@ -6,16 +6,21 @@ from datetime import date
 from typing import List, Optional, cast
 
 import strawberry
-from strawberry.types import Info
-
 from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.routers.graphql.inputs import ExperimentIdentifierInput
 from aqueductcore.backend.routers.graphql.resolvers.experiment_resolver import (
+    get_current_user_info,
     get_experiment,
     get_expriments,
 )
 from aqueductcore.backend.routers.graphql.resolvers.tags_resolver import get_tags
-from aqueductcore.backend.routers.graphql.types import ExperimentData, Experiments, Tags
+from aqueductcore.backend.routers.graphql.types import (
+    ExperimentData,
+    Experiments,
+    Tags,
+    UserInfo,
+)
+from strawberry.types import Info
 
 
 @strawberry.input
@@ -51,6 +56,13 @@ class TagsFilters:
 @strawberry.type
 class Query:
     """GraphQL query controller."""
+
+    @strawberry.field
+    async def get_current_user_info(self, info: Info) -> UserInfo:
+        """Resolver for getting the currently logged in user info."""
+        context = cast(ServerContext, info.context)
+
+        return get_current_user_info(context=context)
 
     @strawberry.field
     async def experiments(

--- a/aqueductcore/backend/routers/graphql/query_schema.py
+++ b/aqueductcore/backend/routers/graphql/query_schema.py
@@ -6,6 +6,8 @@ from datetime import date
 from typing import List, Optional, cast
 
 import strawberry
+from strawberry.types import Info
+
 from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.routers.graphql.inputs import ExperimentIdentifierInput
 from aqueductcore.backend.routers.graphql.resolvers.experiment_resolver import (
@@ -20,7 +22,6 @@ from aqueductcore.backend.routers.graphql.types import (
     Tags,
     UserInfo,
 )
-from strawberry.types import Info
 
 
 @strawberry.input

--- a/aqueductcore/backend/routers/graphql/resolvers/experiment_resolver.py
+++ b/aqueductcore/backend/routers/graphql/resolvers/experiment_resolver.py
@@ -11,7 +11,11 @@ from aqueductcore.backend.routers.graphql.inputs import (
     ExperimentIdentifierInput,
     IDType,
 )
-from aqueductcore.backend.routers.graphql.types import ExperimentData, Experiments
+from aqueductcore.backend.routers.graphql.types import (
+    ExperimentData,
+    Experiments,
+    UserInfo,
+)
 from aqueductcore.backend.routers.graphql.utils import experiment_model_to_node
 from aqueductcore.backend.services.experiment import (
     get_all_experiments,
@@ -22,6 +26,17 @@ from aqueductcore.backend.services.validators import MAX_EXPERIMENTS_PER_REQUEST
 
 if TYPE_CHECKING:
     from aqueductcore.backend.routers.graphql.query_schema import ExperimentFiltersInput
+
+
+def get_current_user_info(
+    context: ServerContext,
+) -> UserInfo:
+    """Resolve all experiments."""
+
+    return UserInfo(
+        username=context.user_info.username,
+        scopes=[scope.value for scope in context.user_info.scopes],
+    )
 
 
 async def get_expriments(

--- a/aqueductcore/backend/routers/graphql/types.py
+++ b/aqueductcore/backend/routers/graphql/types.py
@@ -7,10 +7,11 @@ from typing import List, Optional, cast
 from uuid import UUID
 
 import strawberry
+from strawberry.types import Info
+
 from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.services.experiment import get_experiment_files
 from aqueductcore.backend.settings import settings
-from strawberry.types import Info
 
 
 async def get_files(info: Info, root: ExperimentData) -> List[ExperimentFile]:

--- a/aqueductcore/backend/routers/graphql/types.py
+++ b/aqueductcore/backend/routers/graphql/types.py
@@ -7,11 +7,10 @@ from typing import List, Optional, cast
 from uuid import UUID
 
 import strawberry
-from strawberry.types import Info
-
 from aqueductcore.backend.context import ServerContext
 from aqueductcore.backend.services.experiment import get_experiment_files
 from aqueductcore.backend.settings import settings
+from strawberry.types import Info
 
 
 async def get_files(info: Info, root: ExperimentData) -> List[ExperimentFile]:
@@ -74,6 +73,14 @@ class Experiments:
     total_experiments_count: int = strawberry.field(
         description="Total number of experiments in the filtered dataset"
     )
+
+
+@strawberry.type(description="Current user information")
+class UserInfo:
+    """GraphQL node"""
+
+    username: str = strawberry.field(description="Username.")
+    scopes: List[str] = strawberry.field(description="List of scopes available to the user.")
 
 
 @strawberry.type(description="Paginated list of experiments")

--- a/tests/unittests/test_experiment_services.py
+++ b/tests/unittests/test_experiment_services.py
@@ -6,8 +6,6 @@ from typing import Dict, List, Tuple
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from aqueductcore.backend.context import UserInfo, UserScope
 from aqueductcore.backend.errors import AQDDBExperimentNonExisting
 from aqueductcore.backend.models.experiment import ExperimentCreate, TagCreate
@@ -30,6 +28,7 @@ from aqueductcore.backend.services.utils import (
     tag_model_to_orm,
 )
 from aqueductcore.backend.settings import settings
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.mark.asyncio
@@ -44,7 +43,8 @@ async def test_get_all_experiments(
     await db_session.commit()
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)), db_session=db_session
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
+        db_session=db_session,
     )
 
     assert len(experiments) == len(experiments_data)
@@ -72,7 +72,7 @@ async def test_get_all_experiments_limit_exceeded(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         order_by_creation_date=True,
     )
@@ -90,7 +90,7 @@ async def test_get_all_experiments_ordered_by_creation_date(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         order_by_creation_date=True,
     )
@@ -120,7 +120,7 @@ async def test_get_all_experiments_filtered_by_tag(
     await db_session.commit()
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         tags=["tag1"],
     )
@@ -146,7 +146,7 @@ async def test_get_all_experiments_filtered_by_tag_ordered_by_creation_date(
         await db_session.refresh(db_experiment)
 
     experiments = await get_all_experiments(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         tags=["tag1"],
         order_by_creation_date=True,
@@ -173,7 +173,7 @@ async def test_get_experiment_by_uuid(
     await db_session.commit()
 
     experiment = await get_experiment_by_uuid(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
     )
@@ -199,7 +199,7 @@ async def test_get_experiment_by_alias(
     await db_session.commit()
 
     experiment = await get_experiment_by_alias(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         alias=experiments_data[0].alias,
     )
@@ -225,7 +225,7 @@ async def test_create_db_experiment_pre_existing_data(
     await db_session.commit()
 
     in_db_experiment = await create_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         title="Quantum Communication Protocols for Secure Networks",
         description="Design and evaluate quantum communication protocols to establish secure quantum networks, exploring the potential of quantum key distribution.",
@@ -256,7 +256,7 @@ async def test_create_db_experiment_empty_db(
     """Test create_db_experiment operation with empty database."""
 
     in_db_experiment = await create_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         title="Quantum Communication Protocols for Secure Networks",
         description="Design and evaluate quantum communication protocols to establish secure quantum networks, exploring the potential of quantum key distribution.",
@@ -293,7 +293,7 @@ async def test_update_db_experiment(
     await db_session.commit()
 
     in_db_experiment = await update_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         title="Quantum-enhanced Imaging for Biomedical Applications",
@@ -321,7 +321,7 @@ async def test_add_db_tag_to_experiment(
     await db_session.commit()
 
     in_db_experiment = await add_tag_to_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         tag="important",
@@ -345,7 +345,7 @@ async def test_remove_db_tag_from_experiment(
     await db_session.commit()
 
     in_db_experiment = await remove_tag_from_experiment(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         experiment_id=experiments_data[0].id,
         tag="tag1",
@@ -369,7 +369,7 @@ async def test_get_all_tags_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         include_dangling=True,
     )
@@ -379,7 +379,7 @@ async def test_get_all_tags_dangling(
         assert tags[idx].name == tag.name
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         include_dangling=False,
     )
@@ -408,7 +408,7 @@ async def test_get_all_tags_mix_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         include_dangling=True,
     )
@@ -421,7 +421,7 @@ async def test_get_all_tags_mix_dangling(
     )
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         include_dangling=False,
     )
@@ -447,7 +447,7 @@ async def test_get_all_tags_no_dangling(
     await db_session.commit()
 
     tags = await get_all_tags(
-        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         include_dangling=False,
     )
@@ -471,7 +471,7 @@ async def test_add_and_get_tags_for_experiment(
 
     for experiment in experiments_data:
         experiment_model = await get_experiment_by_uuid(
-            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope)),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
             db_session=db_session,
             experiment_id=experiment.id,
         )
@@ -494,7 +494,7 @@ async def test_get_experiment_files(
 
     for key, value in temp_experiment_files.items():
         files = await get_experiment_files(
-            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
             db_session=db_session,
             experiments_root_dir=str(settings.experiments_dir_path),
             experiment_id=key,
@@ -514,7 +514,7 @@ async def test_get_experiment_files_empty(
 
     for experiment in experiments_data:
         files = await get_experiment_files(
-            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
             db_session=db_session,
             experiments_root_dir=str(settings.experiments_dir_path),
             experiment_id=experiment.id,
@@ -535,7 +535,7 @@ async def test_remove_experiment(
     experiment = experiments_data[0]
 
     delete_experiment_id = await remove_experiment(
-        user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         db_session=db_session,
         experiment_id=experiment.id,
     )
@@ -544,7 +544,7 @@ async def test_remove_experiment(
 
     with pytest.raises(AQDDBExperimentNonExisting):
         await get_experiment_by_uuid(
-            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
             db_session=db_session,
             experiment_id=experiment.id,
         )
@@ -563,7 +563,7 @@ async def test_remove_experiment_invalid_experiment_id(
     experiment_id = uuid4()
     with pytest.raises(AQDDBExperimentNonExisting):
         await remove_experiment(
-            user_info=UserInfo(user_id=experiments_data[0].user_id, scopes=set(UserScope)),
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
             db_session=db_session,
             experiment_id=experiment_id,
         )

--- a/tests/unittests/test_files.py
+++ b/tests/unittests/test_files.py
@@ -7,10 +7,6 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from fastapi import status
-from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from aqueductcore.backend.context import (
     ServerContext,
     UserInfo,
@@ -22,6 +18,9 @@ from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.services.experiment import build_experiment_dir_absolute_path
 from aqueductcore.backend.services.utils import experiment_model_to_orm
 from aqueductcore.backend.settings import settings
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 BYTES_IN_KB = 1024
 
@@ -67,7 +66,8 @@ async def test_file_download(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -94,7 +94,8 @@ async def test_nonexisting_file_download(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -147,7 +148,8 @@ async def test_file_upload_experiment_id(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -215,7 +217,8 @@ async def test_file_upload_max_body_size(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -253,7 +256,8 @@ async def test_file_upload_max_file_size(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -315,7 +319,8 @@ async def test_file_upload_non_existing_body(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency
@@ -350,7 +355,8 @@ async def test_file_upload_invalid_filename(
 
     async def override_context_dependency() -> AsyncGenerator[ServerContext, None]:
         yield ServerContext(
-            db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+            db_session=db_session,
+            user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
         )
 
     app.dependency_overrides[context_dependency] = override_context_dependency

--- a/tests/unittests/test_graphql_mutations.py
+++ b/tests/unittests/test_graphql_mutations.py
@@ -5,9 +5,6 @@ from typing import List
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-from strawberry import Schema
-
 from aqueductcore.backend.context import ServerContext, UserInfo, UserScope
 from aqueductcore.backend.models.experiment import ExperimentCreate
 from aqueductcore.backend.routers.graphql.mutations_schema import Mutation
@@ -20,6 +17,9 @@ from aqueductcore.backend.services.validators import (
     MAX_EXPERIMENT_TITLE_LENGTH,
 )
 from aqueductcore.backend.settings import settings
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry import Schema
+
 from tests.unittests.initial_data import experiment_data
 
 
@@ -260,7 +260,8 @@ async def test_create_experiment_invalid_title(
 
     schema = Schema(query=Query, mutation=Mutation)
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(create_experiment_mutation_invalid_title, context_value=context)
 
@@ -287,7 +288,8 @@ async def test_create_experiment_invalid_description(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(
         create_experiment_mutation_invalid_description, context_value=context
@@ -316,7 +318,8 @@ async def test_create_experiment_invalid_tags(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(create_experiment_mutation_invalid_tags, context_value=context)
 
@@ -341,7 +344,8 @@ async def test_create_experiment_over_limit_tags(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(create_experiment_mutation_over_limit_tags, context_value=context)
 
@@ -369,7 +373,8 @@ async def test_update_experiment(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(update_experiment_mutation, context_value=context)
 
@@ -400,7 +405,8 @@ async def test_add_tag_to_experiment(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(add_tag_to_experiment_mutation, context_value=context)
 
@@ -428,7 +434,8 @@ async def test_remove_tag_from_experiment(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(remove_tag_from_experiment_mutation, context_value=context)
 
@@ -456,7 +463,8 @@ async def test_remove_experiment(
     schema = Schema(query=Query, mutation=Mutation)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(remove_experiment_mutation, context_value=context)
 

--- a/tests/unittests/test_graphql_queries.py
+++ b/tests/unittests/test_graphql_queries.py
@@ -5,9 +5,6 @@ from typing import Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-from strawberry import Schema
-
 from aqueductcore.backend.context import ServerContext, UserInfo, UserScope
 from aqueductcore.backend.models.experiment import (
     ExperimentCreate,
@@ -30,6 +27,8 @@ from aqueductcore.backend.services.validators import (
     MAX_TAGS_PER_REQUEST,
 )
 from aqueductcore.backend.settings import settings
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry import Schema
 
 single_experiment_query = """
 query MyQuery($experimentIdentifier: ExperimentIdentifierInput!) {
@@ -308,7 +307,8 @@ async def test_query_all_experiments(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(all_experiments_query, context_value=context)
 
@@ -348,7 +348,8 @@ async def test_query_all_experiments_invalid_limit(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(all_experiments_invalid_limit_query, context_value=context)
 
@@ -376,7 +377,8 @@ async def test_query_all_experiments_title_filter(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
@@ -404,7 +406,8 @@ async def test_query_all_experiments_max_tags_filter(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(all_experiments_invalid_title_filter_query, context_value=context)
 
@@ -432,7 +435,8 @@ async def test_query_single_experiment(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
 
     # check with UUID
@@ -487,7 +491,8 @@ async def test_filter_by_tags_experiments(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(filter_by_tag_query, context_value=context)
 
@@ -511,7 +516,8 @@ async def test_filter_by_title_experiments(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(filter_by_title_query, context_value=context)
 
@@ -541,7 +547,8 @@ async def test_query_all_tags_all(
 
     # enable dangling tags
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(
         all_tags_query,
@@ -596,7 +603,8 @@ async def test_query_all_tags_no_dangling(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(
         all_tags_query,
@@ -633,7 +641,8 @@ async def test_query_over_limit_all_tags(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(tags_pagination_over_limit_query, context_value=context)
 
@@ -654,7 +663,8 @@ async def test_query_pagination_tags(
     schema = Schema(query=Query)
 
     context = ServerContext(
-        db_session=db_session, user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope))
+        db_session=db_session,
+        user_info=UserInfo(user_id=uuid4(), scopes=set(UserScope), username="admin"),
     )
     resp = await schema.execute(tags_pagination_query, context_value=context)
 


### PR DESCRIPTION
This PR adds a new node to the GraphQL endpoint that returns the username and scopes from the provided token. The following snippet shows the available query.
```
query TestQuery {
  getCurrentUserInfo {
    scopes
    username
  }
}
```
`username` is a string type, and `scopes` is a list of string. The following screenshot shows the GraphiQL execution:

![image](https://github.com/AqueductHub/aqueductcore/assets/3809230/57811231-6e0f-4dd9-8d87-4c5b8dfb50fe)
