### PR TITLE
fix(eslint): keep version 8

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -81,7 +81,7 @@ jobs:
         working-directory: aqueductcore/frontend
 
       - name: Log eslint
-        run: pwd
+        run: echo "working directory $(pwd)"
         working-directory: aqueductcore/frontend
 
       - name: Run eslint check

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -80,6 +80,10 @@ jobs:
         run: yarn add eslint
         working-directory: aqueductcore/frontend
 
+      - name: Log eslint
+        run: pwd
+        working-directory: aqueductcore/frontend
+
       - name: Run eslint check
         run: yarn eslint "src/**/*.{js,jsx,ts,tsx,json}"
         working-directory: aqueductcore/frontend

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -76,12 +76,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install eslint
-        run: yarn add eslint
-        working-directory: aqueductcore/frontend
-
-      - name: Log eslint
-        run: echo "working directory $(pwd)"
+      - name: Install packages
+        run: yarn
         working-directory: aqueductcore/frontend
 
       - name: Run eslint check

--- a/aqueductcore/frontend/.eslintignore
+++ b/aqueductcore/frontend/.eslintignore
@@ -1,4 +1,0 @@
-/node_modules/**
-/coverage/**
-/build/**
-/src/types/graphql/__GENERATED__/**

--- a/aqueductcore/frontend/.eslintrc.js
+++ b/aqueductcore/frontend/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-non-null-assertion": "off"
   },
-  ignores: [
+  ignorePatterns: [
     "/node_modules/**",
     "/coverage/**",
     "/build/**",

--- a/aqueductcore/frontend/.eslintrc.js
+++ b/aqueductcore/frontend/.eslintrc.js
@@ -29,6 +29,12 @@ module.exports = {
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-non-null-assertion": "off"
   },
+  ignores: [
+    "/node_modules/**",
+    "/coverage/**",
+    "/build/**",
+    "/src/types/graphql/__GENERATED__/**"
+  ],
   "overrides": [
     {
       "files": [


### PR DESCRIPTION
Due to a new Major release of ESLinst, we're sticking to the Package.json version of ESLIt in this PR.
But it'll be updated in upcoming PRs.