### PR TITLE
fix(readme): Add links for `aqueductcore-dev` images on Dockerhub to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Aqueduct is the open platform that simplifies quantum experiment management.
 
-Intuitive automation and administration features enable you to 
+Intuitive automation and administration features enable you to
 focus on consistently running and scaling up your experiments.
-Powerful APIs and a flexible plugin SDK allow you to easily 
+Powerful APIs and a flexible plugin SDK allow you to easily
 integrate with Aqueduct and streamline your workflow.
 
 This project uses the following main software stack and technologies:
@@ -23,28 +23,25 @@ This project uses the following main software stack and technologies:
 - [Contributing](#contributing)
 - [License](#license)
 
-
-
 ## Installation
 
-To use Aqueduct, you need to install this repo 
-[aqueductcore](https://github.com/AqueductHub/aqueductcore), 
-and the 
-[pyaqueduct](https://github.com/AqueductHub/pyaqueduct) one too. 
+To use Aqueduct, you need to install this repo
+[aqueductcore](https://github.com/AqueductHub/aqueductcore),
+and the
+[pyaqueduct](https://github.com/AqueductHub/pyaqueduct) one too.
 
 ### Install AqueductCore
 
-Aqueduct --- this repo --- is the server software that hosts the main application, 
-the web interface and handles data storage. 
+Aqueduct --- this repo --- is the server software that hosts the main application,
+the web interface and handles data storage.
 
-To install Aqueduct, you need to have docker and docker-compose installed on your machine. 
+To install Aqueduct, you need to have docker and docker-compose installed on your machine.
 [See here](https://docs.docker.com/compose/gettingstarted) for docker install instructions.
-Ensure that docker is running on your machine. 
+Ensure that docker is running on your machine.
 
-1. Copy the below configuration to a file (call it `docker-compose.yaml`, e.g.). 
-(This file also exists as `aqueductcore/scripts/release/docker-compose.yaml`. 
-You can just copy it to the dir where you will work from.)
-
+1. Copy the below configuration to a file (call it `docker-compose.yaml`, e.g.).
+   (This file also exists as `aqueductcore/scripts/release/docker-compose.yaml`.
+   You can just copy it to the dir where you will work from.)
 
 ```yaml
 version: "3"
@@ -79,17 +76,21 @@ services:
 
 You can find `docker-compose.yaml` file under `aqueductcore/scripts/release` directory.
 
-2. If you now run `docker compose -f docker-compose.yaml up -d` in the directory where the file is, 
-docker will use the yaml file to pull Aqueduct's docker image, set local environment variables, and
-start the server. 
+2. If you now run `docker compose -f docker-compose.yaml up -d` in the directory where the file is,
+   docker will use the yaml file to pull Aqueduct's docker image, set local environment variables, and
+   start the server.
 
 3. Start your browser and point it to `https://localhost`.
 
 For more information please check the [documentation](https://aqueducthub.github.io/aqueductcore/).
 
+#### Development Docker Images
+
+You can find development docker images from the head of the main branch on DockerHub, `aqueducthub/aqueductcore-dev:latest`. The images are built after each commit or pull request merge to the `main` branch.
+
 ### Install PyAqueduct
 
-[PyAqueduct](https://github.com/AqueductHub/pyaqueduct) allows easy programmatic manipulation of experiment objects. 
+[PyAqueduct](https://github.com/AqueductHub/pyaqueduct) allows easy programmatic manipulation of experiment objects.
 
 ```bash
 pip install pyaqueduct
@@ -97,19 +98,18 @@ pip install pyaqueduct
 
 You can find more information about how to use PyAqueduct [here](https://aqueducthub.github.io/pyaqueduct/) in the docs.
 
-
 ## Developers Setup Guide
 
 Read this section if you want to set up the project as a contributor.
 
 0. Prerequisites
 
-- Python (version 3.8 or higher) installed on your system 
-- PostgreSQL (version 15 or higher) installed and running 
-- Node.js (v20.11.1 or higher) installed 
+- Python (version 3.8 or higher) installed on your system
+- PostgreSQL (version 15 or higher) installed and running
+- Node.js (v20.11.1 or higher) installed
 
 1. Clone the repository and change the directory into the root of the project.
-2. We recommend [VSCode](https://code.visualstudio.com) as the dev environment. If you start VS Code in the repo root, it will start up dev docker container. Have a look [here](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) for more information on developing using VS Code. 
+2. We recommend [VSCode](https://code.visualstudio.com) as the dev environment. If you start VS Code in the repo root, it will start up dev docker container. Have a look [here](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) for more information on developing using VS Code.
 3. Run the Server
 
    1. Navigate to the project's root folder.


### PR DESCRIPTION
This PR adds the information about the name of the docker image used for development on the README.md file. Later, once we have a developer section in the docs, this could be added there too, but at this time the docs only contain release information.