### PR TITLE
feat(ci): License report Github action and scripts

### DIFF
--- a/.github/workflows/license_report.yml
+++ b/.github/workflows/license_report.yml
@@ -1,0 +1,28 @@
+name: Generate license report of dependencies.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install packages
+        run: poetry install
+
+      - name: Create a markdown file with contents
+        id: sets-licenses
+        run: |
+          ci/generate_license_report.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: License Report
+          path: license_report.md

--- a/aqueductcore/frontend/package.json
+++ b/aqueductcore/frontend/package.json
@@ -19,8 +19,7 @@
     "lint:eslint": "eslint --ext .js,.ts,.tsx,.html src/",
     "format:eslint": "eslint --ext .js,.ts,.tsx,.html src/ --fix",
     "lint:prettier": "prettier \"src/**/*.{js,ts,tsx,html}\" --check",
-    "format:prettier": "prettier \"src/**/*.{js,ts,tsx,html}\" --write",
-    "check-licenses": "license-report --output=html --only=prod,dev --fields=name --fields=installedVersion --fields=licenseType"
+    "format:prettier": "prettier \"src/**/*.{js,ts,tsx,html}\" --write"
   },
   "dependencies": {
     "@apollo/client": "^3.9.5",

--- a/ci/generate_license_report.sh
+++ b/ci/generate_license_report.sh
@@ -7,7 +7,24 @@ SCRIPT_DIR=$(dirname $FULL_PATH)
 PROJECT_ROOT=$SCRIPT_DIR/..
 FRONTEND_DIR=$PROJECT_ROOT/aqueductcore/frontend
 
-backend_licenses=$(poetry run pip-licenses --format=html --order=license)
-frontend_licenses=$(yarn --cwd $FRONTEND_DIR run check-licenses | sed -n '/<table>/,/<\/table>/p')
+set -e
+set -o pipefail
 
-echo "<h3>Dependency License List</h3><details><summary>Used Python Packages' Licenses</summary>$backend_licenses</details><details><summary>Used Node Modules' Licenses</summary>$frontend_licenses</details>" > licenses.html
+cd $PROJECT_ROOT
+
+if [[ -z $(which poetry) ]]; then
+    echo "Installing poetry"
+    export POETRY_HOME=$HOME/.local
+    curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
+    export PATH="$POETRY_HOME/bin:$PATH"
+    poetry config virtualenvs.in-project false
+fi
+
+
+yarn install --cwd $FRONTEND_DIR
+
+export BACKEND_LICENSES=$(poetry run pip-licenses --format=markdown --order=license)
+# export FRONTEND_LICENSES=$(yarn --cwd $FRONTEND_DIR run check-licenses | sed -n '/<table>/,/<\/table>/p')
+export FRONTEND_LICENSES=$(yarn --cwd $FRONTEND_DIR run -s license-report --only=prod --config=$SCRIPT_DIR/license-report-config.json)
+
+cat $SCRIPT_DIR/license_report_template.md | envsubst > license_report.md

--- a/ci/generate_license_report.sh
+++ b/ci/generate_license_report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script generates license html table that will be posted in comment on PR
+# This script generates license table in a markdown file.
 
 FULL_PATH=$(realpath $0)
 SCRIPT_DIR=$(dirname $FULL_PATH)
@@ -24,7 +24,6 @@ fi
 yarn install --cwd $FRONTEND_DIR
 
 export BACKEND_LICENSES=$(poetry run pip-licenses --format=markdown --order=license)
-# export FRONTEND_LICENSES=$(yarn --cwd $FRONTEND_DIR run check-licenses | sed -n '/<table>/,/<\/table>/p')
 export FRONTEND_LICENSES=$(yarn --cwd $FRONTEND_DIR run -s license-report --only=prod --config=$SCRIPT_DIR/license-report-config.json)
 
 cat $SCRIPT_DIR/license_report_template.md | envsubst > license_report.md

--- a/ci/license-report-config.json
+++ b/ci/license-report-config.json
@@ -1,0 +1,24 @@
+{
+    "output": "markdown",
+    "fields": [
+        "name",
+        "installedVersion",
+        "licenseType"
+    ],
+    "tablemarkOptions": {
+        "columns": [
+            {
+                "name": "Name",
+                "align": "center"
+            },
+            {
+                "name": "Version",
+                "align": "center"
+            },
+            {
+                "name": "License",
+                "align": "center"
+            }
+        ]
+    }
+}

--- a/ci/license_report_template.md
+++ b/ci/license_report_template.md
@@ -1,0 +1,9 @@
+# Aqueduct Core License Report
+
+## Python Packages
+
+${BACKEND_LICENSES}
+
+## Node.js Packages
+
+${FRONTEND_LICENSES}


### PR DESCRIPTION
This PR adds the required workflow and scripts to generate license reports for only the production Python and Node.js packages as markdown reports. The generated file is uploaded as an artifact to the action and it is triggered manually.