### PR TITLE
feat(plugins): #91 natural support of venv's and requirements.

### DIFF
--- a/aqueductcore/backend/models/plugin.py
+++ b/aqueductcore/backend/models/plugin.py
@@ -255,6 +255,7 @@ class Plugin(BaseModel):
 
     @property
     def folder(self):
+        """ Folder with plugin specification. Raises if not initialised. """
         if self._folder is None:
             raise AQDFilesPathError(f"Plugin {self.name} folder is not known.")
         return self._folder

--- a/aqueductcore/backend/models/plugin.py
+++ b/aqueductcore/backend/models/plugin.py
@@ -120,6 +120,7 @@ class PluginFunction(BaseModel):
             self,
             plugin: Plugin,
             params: dict,
+            python: str | Path | None = None,
             timeout: int=60) -> PluginExecutionResult:
         """Passes parameters to the function code and awaits
         execution results
@@ -142,8 +143,12 @@ class PluginFunction(BaseModel):
         cwd = Path.home()
         if plugin.manifest_file:
             cwd = Path(plugin.manifest_file).parent
+
+        rich_script = self.script
+        if python:
+            rich_script = rich_script.replace("$python ", f"{python} ")
         with subprocess.Popen(
-            self.script,
+            rich_script,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -203,6 +208,7 @@ class Plugin(BaseModel):
     manifest_file: Optional[str] = None
     aqueduct_key: Optional[str] = None
     params: Optional[Dict[str, Any]] = None
+    folder: Path = Path.home()
 
     @classmethod
     def from_folder(cls, path: Path) -> Plugin:
@@ -223,6 +229,7 @@ class Plugin(BaseModel):
             # TODO: somehow generate and pass it here
             plugin.aqueduct_key = ""
             plugin.validate_object()
+            plugin.folder = path
             return plugin
 
     def get_function(self, name: str) -> PluginFunction:

--- a/aqueductcore/backend/models/plugin.py
+++ b/aqueductcore/backend/models/plugin.py
@@ -208,7 +208,7 @@ class Plugin(BaseModel):
     manifest_file: Optional[str] = None
     aqueduct_key: Optional[str] = None
     params: Optional[Dict[str, Any]] = None
-    folder: Path = Path.home()
+    _folder: Optional[Path] = None
 
     @classmethod
     def from_folder(cls, path: Path) -> Plugin:
@@ -229,7 +229,7 @@ class Plugin(BaseModel):
             # TODO: somehow generate and pass it here
             plugin.aqueduct_key = ""
             plugin.validate_object()
-            plugin.folder = path
+            plugin._folder = path
             return plugin
 
     def get_function(self, name: str) -> PluginFunction:
@@ -252,3 +252,9 @@ class Plugin(BaseModel):
             raise AQDValidationError("Plugin should have a name.")
         for func in self.functions:
             func.validate_object()
+
+    @property
+    def folder(self):
+        if self._folder is None:
+            raise AQDFilesPathError(f"Plugin {self.name} folder is not known.")
+        return self._folder

--- a/aqueductcore/backend/routers/graphql/types.py
+++ b/aqueductcore/backend/routers/graphql/types.py
@@ -103,6 +103,7 @@ class PluginParameterType:
     description: Optional[str]
     data_type: str
     default_value: Optional[str]
+    options: Optional[List[str]]
 
 
 @strawberry.type
@@ -150,6 +151,7 @@ class PluginInfo:
                         description=parameter.description,
                         data_type=parameter.data_type,
                         default_value=parameter.default_value,
+                        options=parameter.options,
                     )
                 )
             var = function.get_default_experiment_parameter()

--- a/aqueductcore/backend/services/plugin_executor.py
+++ b/aqueductcore/backend/services/plugin_executor.py
@@ -75,16 +75,17 @@ class PluginExecutor:
         """
         where = cls.get_plugin(plugin).folder
         if not where.exists() or where.is_file():
-            raise AQDValidationError(f"Plugin folder `{where}` does not exist")
+            raise AQDValidationError(f"Plugin folder `{where}` does not exist.")
         venv_folder = where / VENV_FOLDER
         if venv_folder.exists() and venv_folder.is_file():
-            raise AQDValidationError(f"Venv `{venv_folder}` is not a folder")
+            raise AQDValidationError(f"Venv `{venv_folder}` is not a folder.")
         return venv_folder.exists()
 
     @classmethod
-    def ensure_venv_python(cls, plugin: str) -> Path:
+    def create_venv_python_if_not_present(cls, plugin: str) -> Path:
         """ If virtual environment is not present in plugin folder,
-        it is created and requirements are installed
+        it is created and requirements are installed. The method
+        returns python executable inside this venv.
 
         Args:
             plugin: plugin name.
@@ -99,7 +100,7 @@ class PluginExecutor:
         python_bin = (venv_dir / PYTHON_BINARY).absolute()
         if cls.is_venv_present(plugin=plugin):
             return python_bin
-        venv.create(venv_dir, system_site_packages=True, with_pip=True)
+        venv.create(venv_dir, system_site_packages=False, with_pip=True)
         cls.try_install_requirements_txt(plugin=plugin, python=python_bin)
         cls.try_install_pyproject_toml(plugin=plugin, python=python_bin)
         return python_bin
@@ -167,7 +168,7 @@ class PluginExecutor:
         """
         plugin_object = cls.get_plugin(plugin)
         function_object = plugin_object.get_function(function)
-        python = cls.ensure_venv_python(plugin=plugin)
+        python = cls.create_venv_python_if_not_present(plugin=plugin)
         return function_object.execute(
             plugin=plugin_object,
             params=params,

--- a/plugins/python-example/manifest.yml
+++ b/plugins/python-example/manifest.yml
@@ -32,11 +32,7 @@ functions:
     # it may drop and recreate
     # its environment on each run.
     script: >
-      if [ ! -d "./plugin-venv" ]; then
-          python -m venv .plugin-venv;
-          ./.plugin-venv/bin/pip install requests pyaqueduct --quiet;
-      fi;
-      ./.plugin-venv/bin/python solve_alpha.py
+      $python solve_alpha.py
 
     # arguments of the function
     parameters:

--- a/plugins/python-example/requirements.txt
+++ b/plugins/python-example/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.0.0
+pyaqueduct==0.0.7

--- a/tests/unittests/test_plugin_executor.py
+++ b/tests/unittests/test_plugin_executor.py
@@ -225,8 +225,6 @@ class TestPluginExecutor:
         assert (venv / PYTHON_BINARY).exists()
         # pip is there
         assert (venv / "bin/pip").exists()
-        # requests is there
-        assert (venv / "bin/pip").exists()
         # assert requests are installed
         assert list(venv.glob("lib*/python*/site-packages/requests"))
         # assert requests are installed

--- a/tests/unittests/test_plugin_executor.py
+++ b/tests/unittests/test_plugin_executor.py
@@ -1,9 +1,10 @@
+import shutil
 import pytest
 
 from pydantic import ValidationError
 
-from aqueductcore.backend.services.plugin_executor import PluginExecutor
-from pathlib import Path
+from aqueductcore.backend.services.plugin_executor import (
+    PluginExecutor, VENV_FOLDER, PYTHON_BINARY)
 
 from aqueductcore.backend.models.plugin import (
     Plugin,
@@ -203,3 +204,30 @@ class TestPluginExecutor:
         assert result.stderr == ""
         assert result.return_code == 0
         assert result.stdout == "x = -i sqrt(7)\nx = i sqrt(7)\n"
+
+    def test_plugin_venv_is_created_execute(self):
+        plugin = PluginExecutor.get_plugin("Wolfram alpha solution plugin")
+        venv = plugin.folder / VENV_FOLDER
+        # make sure there is no venv
+        shutil.rmtree(venv, ignore_errors=True)
+        # it will fail, but after the venv creation
+        try:
+            PluginExecutor.execute(
+                "Wolfram alpha solution plugin",
+                "solve as text",
+                {}
+            )
+        except:
+            pass
+        # venv is created
+        assert venv.exists()
+        # python is there
+        assert (venv / PYTHON_BINARY).exists()
+        # pip is there
+        assert (venv / "bin/pip").exists()
+        # requests is there
+        assert (venv / "bin/pip").exists()
+        # assert requests are installed
+        assert list(venv.glob("lib*/python*/site-packages/requests"))
+        # assert requests are installed
+        assert list(venv.glob("lib*/python*/site-packages/pyaqueduct"))

--- a/tests/unittests/test_plugin_executor.py
+++ b/tests/unittests/test_plugin_executor.py
@@ -167,7 +167,7 @@ class TestPluginExecutor:
                             PluginParameter(
                                 name="var1",
                                 description="descr",
-                                data_type=SupportedTypes.TEXTAREA.value,
+                                data_type=SupportedTypes.TEXTAREA,
                             )
                         ],
                     ),
@@ -179,11 +179,21 @@ class TestPluginExecutor:
     def test_plugin_validation_ok(self, plugin):
         plugin.validate_object()
 
+    def test_plugin_echo(self):
+        plugin = PluginExecutor.get_plugin("Dummy plugin")
+        result = PluginExecutor.execute(
+            plugin="Dummy plugin",
+            function="echo",
+            params={"var1": "text", "var2": 1, "var3": 2.2, "var4": "20240229-5689864ffd94",
+             "var5": "text\narea", "var6": 0, "var7": "string2"},
+        )
+        assert result.return_code == 0
+
     @pytest.mark.skip
     def test_plugin_wolfram_alpha(self):
-        wolfram_alpha = Plugin.from_folder(Path("plugins/python-example"))
-        result = wolfram_alpha.functions[0].execute(
-            wolfram_alpha,
+        result = PluginExecutor.execute(
+            "Wolfram alpha solution plugin",
+            "solve as text",
             {
                 "equation": "x^2 + 7 = 0",
                 "experiment": "20240229-5689864ffd94",

--- a/tests/unittests/test_plugins.py
+++ b/tests/unittests/test_plugins.py
@@ -6,7 +6,6 @@ from aqueductcore.backend.models.plugin import (
     SupportedTypes,
 )
 from aqueductcore.backend.services.plugin_executor import PluginExecutor
-from aqueductcore.backend.errors import AQDValidationError
 
 
 class TestPluginModel:    
@@ -61,4 +60,15 @@ class TestPluginModel:
         plugin = PluginExecutor.get_plugin("Dummy plugin")
         echo = plugin.get_function("echo")
         param = echo.get_default_experiment_parameter()
-        assert param.name == "var4" and param.data_type == SupportedTypes.EXPERIMENT.value
+        assert param.name == "var4" and param.data_type == SupportedTypes.EXPERIMENT
+
+    def test_plugin_execute(self):
+        plugin = PluginExecutor.get_plugin("Dummy plugin")
+        echo = plugin.get_function("echo")
+        result = echo.execute(
+            plugin=plugin,
+            params={"var1": "text", "var2": 1, "var3": 2.2,
+                    "var4": "20240229-5689864ffd94",
+                    "var5": "text\narea", "var6": 0, "var7": "string2"},
+        )
+        assert result.return_code == 0


### PR DESCRIPTION
This code adds a few actions, which happen by default for each plugin at first start:
1. venv in created, if doesn't exist
2. if `requirements.txt` is present, `$venv-python -m pip install -r requirements.txt`
3. If `pyproject.toml` is present, `$venv-python -m pip install .`

$python variable is used in scripts to point to a venv python.