### PR TITLE
feat(cli): Modules to import/export metadata and experiment files into the Aqueduct instance

### DIFF
--- a/aqueductcore/__init__.py
+++ b/aqueductcore/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("aqueductcore")

--- a/aqueductcore/__init__.py
+++ b/aqueductcore/__init__.py
@@ -1,3 +1,5 @@
+"""Aqueduct Core."""
+
 import importlib.metadata
 
 __version__ = importlib.metadata.version("aqueductcore")

--- a/aqueductcore/backend/errors.py
+++ b/aqueductcore/backend/errors.py
@@ -36,3 +36,7 @@ class AQDFilesPathError(AQDError):
 
 class AQDCouldNotRemoveExperiment(AQDError):
     """Exception raised when experiment-tag-map rows could not be deleted"""
+
+
+class AQDImportError(AQDError):
+    """Exception raised when there is an error with import."""

--- a/aqueductcore/backend/services/experiment.py
+++ b/aqueductcore/backend/services/experiment.py
@@ -273,10 +273,11 @@ async def create_experiment(
     tags_in_db_statement = select(orm.Tag).filter(orm.Tag.key.in_(input_tag_keys))
     tags_in_db = (await db_session.execute(tags_in_db_statement)).scalars().all()
 
-    tags_orm = []
-    key_list = [item.key for item in tags_in_db]
+    tags_orm: List[orm.Tag] = []
+    tags_orm.extend(tags_in_db)
+    db_key_list = [item.key for item in tags_in_db]
     for tag in set(tags):
-        if tag.lower() not in key_list:
+        if tag.lower() not in db_key_list:
             tags_orm.append(orm.Tag(name=tag, key=tag.lower()))
 
     # get last created experiment of the day
@@ -318,9 +319,8 @@ async def create_experiment(
         created_at=datetime.now(timezone.utc),
         updated_at=datetime.now(timezone.utc),
     )
-    db_session.add(db_experiment)
 
-    db_experiment.tags.extend(tags_in_db)
+    db_session.add(db_experiment)
 
     await db_session.commit()
 

--- a/aqueductcore/cli/export.py
+++ b/aqueductcore/cli/export.py
@@ -42,10 +42,11 @@ class Exporter:
 
         data = AqueductData(version=__version__, variant=AqueductVariant.CORE, users=[])
         for user in result.unique().scalars().all():
-            user_data = User(uid=user.id, username=user.username, experiments=[])
+            user_data = User(uuid=user.id, username=user.username, experiments=[])
             for experiment in user.experiments:
                 user_data.experiments.append(
                     Experiment(
+                        uuid=experiment.id,
                         eid=experiment.alias,
                         title=experiment.title,
                         description=experiment.description,
@@ -75,7 +76,7 @@ class Exporter:
                 if entry.is_file():
                     total += entry.stat().st_size
                 elif entry.is_dir():
-                    total += Exporter._get_dir_size(entry.path)
+                    total += cls._get_dir_size(entry.path)
         return total
 
     @classmethod
@@ -116,17 +117,13 @@ class Exporter:
                                 entry_size = entry.stat().st_size
                                 tar.add(
                                     name=entry.path,
-                                    arcname=os.path.join(
-                                        Exporter.EXPERIMENTS_BASE_DIR_NAME, entry.name
-                                    ),
+                                    arcname=os.path.join(cls.EXPERIMENTS_BASE_DIR_NAME, entry.name),
                                 )
                             elif entry.is_dir(follow_symlinks=False):
-                                entry_size = Exporter._get_dir_size(entry.path)
+                                entry_size = cls._get_dir_size(entry.path)
                                 tar.add(
                                     name=entry.path,
-                                    arcname=os.path.join(
-                                        Exporter.EXPERIMENTS_BASE_DIR_NAME, entry.name
-                                    ),
+                                    arcname=os.path.join(cls.EXPERIMENTS_BASE_DIR_NAME, entry.name),
                                 )
                             if progress:
                                 progress(entry_size)

--- a/aqueductcore/cli/export.py
+++ b/aqueductcore/cli/export.py
@@ -1,0 +1,139 @@
+"""Aqueduct module for exporting data from instance."""
+
+from __future__ import annotations
+
+import errno
+import os.path
+import tarfile
+from io import BytesIO
+from typing import Any, Callable, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from aqueductcore import __version__
+from aqueductcore.backend.errors import AQDFilesPathError
+from aqueductcore.backend.models import orm
+from aqueductcore.cli.models import AqueductData, AqueductVariant, Experiment, Tag, User
+from aqueductcore.cli.session import Session
+
+
+class Exporter:
+    """Aqueduct exporter class."""
+
+    EXPERIMENTS_BASE_DIR_NAME = "experiments_files"
+
+    @classmethod
+    def export_experiments_metadata(
+        cls,
+        db_session: Session,
+    ) -> AqueductData:
+        """Export instance data as an object.
+
+        Args:
+            db_session: Database session to load metadata from.
+
+        Returns:
+            Instance metadata as an AqueductData object.
+
+        """
+        statement = select(orm.User)
+
+        result = db_session.execute(statement)
+
+        data = AqueductData(version=__version__, variant=AqueductVariant.CORE, users=[])
+        for user in result.unique().scalars().all():
+            user_data = User(uid=user.id, username=user.username, experiments=[])
+            for experiment in user.experiments:
+                user_data.experiments.append(
+                    Experiment(
+                        eid=experiment.alias,
+                        title=experiment.title,
+                        description=experiment.description,
+                        created_at=experiment.created_at,
+                        updated_at=experiment.updated_at,
+                        tags=[Tag(key=item.key, name=item.name) for item in experiment.tags],
+                    )
+                )
+            data.users.append(user_data)
+
+        return data
+
+    @classmethod
+    def _get_dir_size(cls, experiments_dir: str) -> int:
+        """Get the directory size in bytes given the path.
+
+        Args:
+            experiments_dir: Path to find the files size.
+
+        Returns:
+            Size of the directory including its files recursively in bytes.
+
+        """
+        total = 0
+        with os.scandir(experiments_dir) as it:
+            for entry in it:
+                if entry.is_file():
+                    total += entry.stat().st_size
+                elif entry.is_dir():
+                    total += Exporter._get_dir_size(entry.path)
+        return total
+
+    @classmethod
+    def export_artifact(
+        cls,
+        metadata: bytes,
+        output_fileobj: BytesIO,
+        metadata_filename="metadata.json",
+        experiments_root: Optional[str] = None,
+        progress: Optional[Callable[[int], Any]] = None,
+    ) -> None:
+        """Export experiments' files and metadata to the desired location as a tar file with
+        gzip compression.
+
+        Args:
+            metadata: Aqueduct metadata as bytes.
+            output_fileobj: Output file object for the generated tar file.
+            metadata_filename: Metadata file name to get into the generated tar file.
+            experiments_root: Experiments rood directory of the Aqueduct instance.
+            progress: Call back with processed data information to show progress.
+
+        """
+        try:
+            with tarfile.open(mode="w:gz", fileobj=output_fileobj) as tar:
+                metadata_tarinfo = tarfile.TarInfo(metadata_filename)
+                metadata_tarinfo.size = len(metadata)
+                tar.addfile(
+                    tarinfo=metadata_tarinfo,
+                    fileobj=BytesIO(metadata),
+                )
+                if progress:
+                    progress(metadata_tarinfo.size)
+                if experiments_root:
+                    with os.scandir(experiments_root) as dir_iterator:
+                        for entry in dir_iterator:
+                            entry_size = 0
+                            if entry.is_file(follow_symlinks=False):
+                                entry_size = entry.stat().st_size
+                                tar.add(
+                                    name=entry.path,
+                                    arcname=os.path.join(
+                                        Exporter.EXPERIMENTS_BASE_DIR_NAME, entry.name
+                                    ),
+                                )
+                            elif entry.is_dir(follow_symlinks=False):
+                                entry_size = Exporter._get_dir_size(entry.path)
+                                tar.add(
+                                    name=entry.path,
+                                    arcname=os.path.join(
+                                        Exporter.EXPERIMENTS_BASE_DIR_NAME, entry.name
+                                    ),
+                                )
+                            if progress:
+                                progress(entry_size)
+
+        except OSError as error:
+            if error.errno in (errno.EACCES, errno.EPERM):  # Permission denied
+                raise AQDFilesPathError("Error in reading the files: Permission denied.") from error
+
+            raise AQDFilesPathError("Unknown Error in accessing the file system.") from error

--- a/aqueductcore/cli/export.py
+++ b/aqueductcore/cli/export.py
@@ -15,7 +15,6 @@ from aqueductcore import __version__
 from aqueductcore.backend.errors import AQDFilesPathError
 from aqueductcore.backend.models import orm
 from aqueductcore.cli.models import AqueductData, AqueductVariant, Experiment, Tag, User
-from aqueductcore.cli.session import Session
 
 
 class Exporter:
@@ -71,8 +70,8 @@ class Exporter:
 
         """
         total = 0
-        with os.scandir(experiments_dir) as it:
-            for entry in it:
+        with os.scandir(experiments_dir) as iterator:
+            for entry in iterator:
                 if entry.is_file():
                     total += entry.stat().st_size
                 elif entry.is_dir():

--- a/aqueductcore/cli/exporter.py
+++ b/aqueductcore/cli/exporter.py
@@ -92,9 +92,8 @@ class Exporter:
         gzip compression.
 
         Args:
-            metadata: Aqueduct metadata as bytes.
-            output_fileobj: Output file object for the generated tar file.
-            metadata_filename: Metadata file name to get into the generated tar file.
+            metadata_bytes: Aqueduct metadata encoded as bytes.
+            tar: Tar file to generate the archive.
             experiments_root: Experiments rood directory of the Aqueduct instance.
             progress: Call back with processed data information to show progress.
 

--- a/aqueductcore/cli/exporter.py
+++ b/aqueductcore/cli/exporter.py
@@ -61,7 +61,7 @@ class Exporter:
         return data
 
     @classmethod
-    def _get_dir_size(cls, experiments_dir: str) -> int:
+    def get_dir_size(cls, experiments_dir: str) -> int:
         """Get the directory size in bytes given the path.
 
         Args:
@@ -77,13 +77,13 @@ class Exporter:
                 if entry.is_file():
                     total += entry.stat().st_size
                 elif entry.is_dir():
-                    total += cls._get_dir_size(entry.path)
+                    total += cls.get_dir_size(entry.path)
         return total
 
     @classmethod
-    def export_artifact(
+    def export_archive(
         cls,
-        metadata: bytes,
+        metadata_bytes: bytes,
         tar: TarFile,
         experiments_root: Optional[str] = None,
         progress: Optional[Callable[[int], Any]] = None,
@@ -102,10 +102,10 @@ class Exporter:
         try:
 
             metadata_tarinfo = TarInfo(cls.METADATA_FILENAME)
-            metadata_tarinfo.size = len(metadata)
+            metadata_tarinfo.size = len(metadata_bytes)
             tar.addfile(
                 tarinfo=metadata_tarinfo,
-                fileobj=BytesIO(metadata),
+                fileobj=BytesIO(metadata_bytes),
             )
             if progress:
                 progress(metadata_tarinfo.size)
@@ -120,7 +120,7 @@ class Exporter:
                                 arcname=os.path.join(cls.EXPERIMENTS_BASE_DIR_NAME, entry.name),
                             )
                         elif entry.is_dir(follow_symlinks=False):
-                            entry_size = cls._get_dir_size(entry.path)
+                            entry_size = cls.get_dir_size(entry.path)
                             tar.add(
                                 name=entry.path,
                                 arcname=os.path.join(cls.EXPERIMENTS_BASE_DIR_NAME, entry.name),

--- a/aqueductcore/cli/importer.py
+++ b/aqueductcore/cli/importer.py
@@ -11,7 +11,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from aqueductcore import __version__
-from aqueductcore.backend.errors import AQDImportError
 from aqueductcore.backend.models import orm
 from aqueductcore.cli.exporter import Exporter
 from aqueductcore.cli.models import AqueductData, Experiment, Tag
@@ -66,13 +65,6 @@ class Importer:
             metadata: Aqueduct metadata object.
 
         """
-        if not cls.check_version_compatible(
-            aqueduct_version=__version__, metadata_version=metadata.version
-        ):
-            raise AQDImportError(
-                f"Version of the imported archive, {metadata.version}, is not "
-                "compatible with current version of Aqueduct instance."
-            )
 
         cur_users_statement = select(orm.User).where(
             orm.User.id.in_([item.uuid for item in metadata.users])
@@ -148,7 +140,8 @@ class Importer:
 
             if member.path == Exporter.METADATA_FILENAME:
                 return None
-            elif member.path.startswith(Exporter.EXPERIMENTS_BASE_DIR_NAME):
+
+            if member.path.startswith(Exporter.EXPERIMENTS_BASE_DIR_NAME):
                 member.path = member.path.replace(f"{Exporter.EXPERIMENTS_BASE_DIR_NAME}/", "")
             return member
 

--- a/aqueductcore/cli/importer.py
+++ b/aqueductcore/cli/importer.py
@@ -134,8 +134,7 @@ class Importer:
 
         Args:
             metadata: Aqueduct metadata as bytes.
-            output_fileobj: Output file object for the generated tar file.
-            metadata_filename: Metadata file name to get into the generated tar file.
+            tar: Tar file to read the archive.
             experiments_root: Experiments rood directory of the Aqueduct instance.
             progress: Call back with processed data information to show progress.
 

--- a/aqueductcore/cli/importer.py
+++ b/aqueductcore/cli/importer.py
@@ -1,0 +1,149 @@
+"""Aqueduct module for importing data from instance."""
+
+from __future__ import annotations
+
+import tarfile
+from tarfile import TarFile
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from packaging.version import Version
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from aqueductcore import __version__
+from aqueductcore.backend.errors import AQDImportError
+from aqueductcore.backend.models import orm
+from aqueductcore.cli.models import AqueductData, Experiment, Tag
+
+
+class Importer:
+    """Aqueduct importer class."""
+
+    @classmethod
+    def check_version_compatible(cls, aqueduct_version: str, metadata_version: str) -> bool:
+        """Check if the metadata version is compatible with the current Aqueduct version.
+
+        Args:
+            metadata_version: Version string in semantic format.
+
+        Returns:
+            True if the version is compatible, False otherwise.
+
+        """
+        version = Version(metadata_version)
+        cur_version = Version(aqueduct_version)
+
+        return cur_version.major == version.major
+
+    @classmethod
+    def get_conflicting_experiments(
+        cls, db_session: Session, experiments: List[Experiment]
+    ) -> Sequence[orm.Experiment]:
+        """Check if there are conflicting experiments with the same EID.
+
+        Args:
+            db_session: Database session to load metadata from.
+            experiments: Experiments to be checked.
+
+        Returns:
+            List of database experiments that are conflicting with the provided ones.
+
+        """
+        conflict_statement = select(orm.Experiment).where(
+            orm.Experiment.alias.in_([item.eid for item in experiments])
+        )
+        conflict_result = db_session.execute(conflict_statement).scalars().all()
+
+        return conflict_result
+
+    @classmethod
+    def import_experiments_metadata(cls, db_session: Session, metadata: AqueductData) -> None:
+        """Import metadata into the database. Conflicts raise database exceptions.
+
+        Args:
+            db_session: Database session to load metadata from.
+            metadata: Aqueduct metadata object.
+
+        """
+        if not cls.check_version_compatible(
+            aqueduct_version=__version__, metadata_version=metadata.version
+        ):
+            raise AQDImportError(
+                f"Version of the imported archive, {metadata.version}, is not "
+                "compatible with current version of Aqueduct instance."
+            )
+
+        cur_users_statement = select(orm.User).where(
+            orm.User.id.in_([item.uuid for item in metadata.users])
+        )
+        cur_db_users = db_session.execute(cur_users_statement).scalars().all()
+        cur_db_users_dict = {item.id: item for item in cur_db_users}
+
+        metadata_experiments: List[Experiment] = []
+        for user in metadata.users:
+            metadata_experiments.extend(user.experiments)
+
+        metadata_tags: Dict[str, Tag] = {}
+        for experiment in metadata_experiments:
+            for tag in experiment.tags:
+                metadata_tags[tag.key] = tag
+
+        cur_db_tags_statement = select(orm.Tag).where(orm.Tag.key.in_(list(metadata_tags.keys())))
+        cur_db_tags = db_session.execute(cur_db_tags_statement).scalars().all()
+        cur_db_tags_dict = {item.key: item for item in cur_db_tags}
+
+        db_tags: Dict[str, orm.Tag] = {}
+        for key, value in metadata_tags.items():
+            if key in cur_db_tags_dict:
+                db_tags[key] = cur_db_tags_dict[key]
+            else:
+                db_tags[key] = orm.Tag(key=key, name=value.name)
+
+        for user in metadata.users:
+            db_user = cur_db_users_dict.get(user.uuid)
+            if not db_user:
+                db_user = orm.User(
+                    id=user.uuid,
+                    username=user.username,
+                )
+                cur_db_users_dict[user.uuid] = db_user
+                db_session.add(db_user)
+
+            for experiment in user.experiments:
+                db_experiment = orm.Experiment(
+                    id=experiment.uuid,
+                    title=experiment.title,
+                    description=experiment.description,
+                    tags=[db_tags[tag.key] for tag in experiment.tags],
+                    alias=experiment.eid,
+                    created_at=experiment.created_at,
+                    updated_at=experiment.updated_at,
+                )
+                db_user.experiments.append(db_experiment)
+
+    @classmethod
+    def import_artifact(
+        cls,
+        tar: TarFile,
+        experiments_root: str,
+        progress: Optional[Callable[[int], Any]] = None,
+    ) -> None:
+        """Import experiments' files and metadata to the desired location as a tar file with
+        gzip compression.
+
+        Args:
+            metadata: Aqueduct metadata as bytes.
+            output_fileobj: Output file object for the generated tar file.
+            metadata_filename: Metadata file name to get into the generated tar file.
+            experiments_root: Experiments rood directory of the Aqueduct instance.
+            progress: Call back with processed data information to show progress.
+
+        """
+
+        def experiments_filter(member: tarfile.TarInfo, _) -> tarfile.TarInfo:
+            """Extraction filter for progress bar."""
+            if progress:
+                progress(member.size)
+            return member
+
+        tar.extractall(path=experiments_root, filter=experiments_filter)

--- a/aqueductcore/cli/models.py
+++ b/aqueductcore/cli/models.py
@@ -44,6 +44,8 @@ class AqueductVariant(str, Enum):
 
 
 class AqueductData(BaseModel):
+    """Aqueduct metadata model."""
+
     version: str
     variant: AqueductVariant
     users: List[User]

--- a/aqueductcore/cli/models.py
+++ b/aqueductcore/cli/models.py
@@ -20,6 +20,7 @@ class Tag(BaseModel):
 class Experiment(BaseModel):
     """Experiment data model."""
 
+    uuid: UUID
     eid: str
     title: str
     description: Optional[str] = None
@@ -31,7 +32,7 @@ class Experiment(BaseModel):
 class User(BaseModel):
     """User data model."""
 
-    uid: UUID
+    uuid: UUID
     username: str
     experiments: List[Experiment]
 

--- a/aqueductcore/cli/models.py
+++ b/aqueductcore/cli/models.py
@@ -1,0 +1,49 @@
+"""Data model for importing and exporting Aqueduct porting data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Tag(BaseModel):
+    """Tag data model."""
+
+    key: str
+    name: str
+
+
+class Experiment(BaseModel):
+    """Experiment data model."""
+
+    eid: str
+    title: str
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    tags: List[Tag]
+
+
+class User(BaseModel):
+    """User data model."""
+
+    uid: UUID
+    username: str
+    experiments: List[Experiment]
+
+
+class AqueductVariant(str, Enum):
+    """Aqueduct variants enumerator."""
+
+    CORE = "core"
+    PRO = "pro"
+
+
+class AqueductData(BaseModel):
+    version: str
+    variant: AqueductVariant
+    users: List[User]

--- a/aqueductcore/cli/session.py
+++ b/aqueductcore/cli/session.py
@@ -1,0 +1,29 @@
+"""Database engine module for database interaction from business logic layer."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from aqueductcore.backend.settings import settings
+
+sync_engine = create_engine(
+    f"postgresql+psycopg2://{settings.postgres_username}:"
+    f"{settings.postgres_password}@{settings.postgres_host}:"
+    f"{settings.postgres_port}/{settings.postgres_db}"
+)
+
+sync_session = sessionmaker(bind=sync_engine, expire_on_commit=False)
+
+
+@contextmanager
+def get_session() -> Generator[Session, None, None]:
+    """Returns database session for SQLAlchemy ORM."""
+    with sync_session() as session:
+        try:
+            yield session
+        finally:
+            session.close()

--- a/aqueductcore/cli/session.py
+++ b/aqueductcore/cli/session.py
@@ -1,29 +1,18 @@
-"""Database engine module for database interaction from business logic layer."""
+"""Database engine module for database session management."""
 
 from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import Engine
 from sqlalchemy.orm import Session, sessionmaker
-
-from aqueductcore.backend.settings import settings
-
-sync_engine = create_engine(
-    f"postgresql+psycopg2://{settings.postgres_username}:"
-    f"{settings.postgres_password}@{settings.postgres_host}:"
-    f"{settings.postgres_port}/{settings.postgres_db}"
-)
-
-sync_session = sessionmaker(bind=sync_engine, expire_on_commit=False)
 
 
 @contextmanager
-def get_session() -> Generator[Session, None, None]:
+def get_session(db_engine: Engine) -> Generator[Session, None, None]:
     """Returns database session for SQLAlchemy ORM."""
-    with sync_session() as session:
-        try:
-            yield session
-        finally:
-            session.close()
+    sync_session = sessionmaker(bind=db_engine, expire_on_commit=False)
+
+    with sync_session.begin() as session:  # pylint: disable=no-member
+        yield session

--- a/poetry.lock
+++ b/poetry.lock
@@ -1369,6 +1369,30 @@ docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1446,6 +1470,17 @@ python-versions = ">=3.6"
 files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -2757,6 +2792,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rich"
+version = "13.7.1"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
 version = "0.18.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -2893,6 +2947,17 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
 
 [[package]]
 name = "six"
@@ -3210,6 +3275,23 @@ files = [
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
+
+[[package]]
+name = "typer"
+version = "0.12.3"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typer-0.12.3-py3-none-any.whl", hash = "sha256:070d7ca53f785acbccba8e7d28b08dcd88f79f1fbda035ade0aecec71ca5c914"},
+    {file = "typer-0.12.3.tar.gz", hash = "sha256:49e73131481d804288ef62598d97a1ceef3058905aa536a1134f90891ba35482"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
+typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "types-protobuf"
@@ -3692,4 +3774,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8,< 3.12"
-content-hash = "277540b978f4785310fae31586936cbadbd4789ee00fdf97e6e58ddc12bab9c3"
+content-hash = "73edec6a053f6e04ec62f90c5036287737debf26af442d69573ac8ef34c2b037"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ pip-licenses = "^4.3"
 pathvalidate = "^3.2"
 python-jose = {version = "^3.3", extras = ["cryptography"]}
 bcrypt = "^4.1"
+typer = "^0.12"
+psycopg2-binary = "^2.9"
+
+[tool.poetry.scripts]
+aqueduct = "aqueductcore.cli:app"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
@@ -49,7 +54,7 @@ mkdocs-material = "^9.4"
 mike = "^2.0"
 aiosqlite = "^0.19"
 alembic = "^1.12"
-psycopg2-binary = "^2.9"
+
 mkdocstrings = {version = "^0.24",extras = ["python"]}
 nbconvert = "^7.14"
 pytz = "^2024.1"

--- a/tests/unittests/cli/conftest.py
+++ b/tests/unittests/cli/conftest.py
@@ -13,7 +13,7 @@ from aqueductcore.backend.models import orm
 
 sync_engine = create_engine("sqlite:///:memory:")
 
-sync_session = sessionmaker(bind=sync_engine, expire_on_commit=False)
+sync_session = sessionmaker(bind=sync_engine, expire_on_commit=False, autoflush=False)
 
 
 @contextmanager

--- a/tests/unittests/cli/conftest.py
+++ b/tests/unittests/cli/conftest.py
@@ -1,0 +1,39 @@
+# pylint: skip-file
+"""Common test fixtures"""
+
+
+from contextlib import contextmanager
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from aqueductcore.backend.models import orm
+
+sync_engine = create_engine("sqlite:///:memory:")
+
+sync_session = sessionmaker(bind=sync_engine, expire_on_commit=False)
+
+
+@contextmanager
+def get_session() -> Generator[Session, None, None]:
+    """Returns database session for SQLAlchemy ORM."""
+    with sync_session() as session:
+        try:
+            yield session
+        finally:
+            session.close()
+
+
+@pytest.fixture
+def db_session():
+    """Session for SQLAlchemy."""
+    with sync_session() as session:
+        orm.Base.metadata.create_all(sync_engine)
+
+        yield session
+
+        orm.Base.metadata.drop_all(sync_engine)
+
+    sync_engine.dispose()

--- a/tests/unittests/cli/test_export.py
+++ b/tests/unittests/cli/test_export.py
@@ -65,7 +65,7 @@ def test_export_experiments_metadata(db_session: Session, experiments_data: List
     assert metadata.version == aqueductcore.__version__
     assert metadata.variant == AqueductVariant.CORE.value
     assert len(metadata.users) == 1
-    assert metadata.users[0].uid == user_id
+    assert metadata.users[0].uuid == user_id
     assert metadata.users[0].username == settings.default_username
 
     # TODO: Add assertions for data equality.

--- a/tests/unittests/cli/test_export.py
+++ b/tests/unittests/cli/test_export.py
@@ -1,0 +1,131 @@
+# pylint: skip-file
+
+import os
+import tarfile
+from datetime import datetime, timezone
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from typing import List
+from uuid import UUID, uuid4
+
+from sqlalchemy.orm import Session
+
+import aqueductcore
+from aqueductcore.backend.models import orm
+from aqueductcore.backend.models.experiment import ExperimentCreate, TagCreate
+from aqueductcore.backend.services.utils import experiment_model_to_orm
+from aqueductcore.backend.settings import settings
+from aqueductcore.cli.export import Exporter
+from aqueductcore.cli.models import AqueductVariant
+
+user_id = uuid4()
+experiment_data = [
+    ExperimentCreate(
+        id=UUID("b7038e5a-c93d-4cac-8d3d-b5a95ead0963"),
+        title="Entangling Possibilities: Quantum Computing Explorations",
+        description="Description for entangling possibilities: quantum computing explorations experiment",
+        tags=[
+            TagCreate(key="tag1", name="Tag1"),
+            TagCreate(key="tag2", name="Tag2"),
+            TagCreate(key="tag3", name="Tag3"),
+        ],
+        alias=f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-1",
+    ),
+    ExperimentCreate(
+        id=UUID("94d7d1a5-0840-481c-8f46-d9873f5fafa4"),
+        title="Shifting Realities: Quantum Computing Challenges",
+        description="Description for shifting realities: quantum computing challenges experiment",
+        tags=[],
+        alias=f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-2",
+    ),
+    ExperimentCreate(
+        id=UUID("852b81bb-ced4-4c8d-8176-9c7184206638"),
+        title="Beyond Bits: Quantum Computing Frontier",
+        description="Description for beyond bits: quantum computing frontier experiment",
+        tags=[],
+        alias=f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-3",
+    ),
+]
+
+
+def test_export_experiments_metadata(db_session: Session, experiments_data: List[ExperimentCreate]):
+    """Test get_all_experiments operation"""
+    db_user = orm.User(id=user_id, username=settings.default_username)
+    db_session.add(db_user)
+
+    for experiment in experiments_data:
+        db_experiment = experiment_model_to_orm(experiment)
+        db_experiment.created_by_user = db_user
+        db_session.add(db_experiment)
+
+    db_session.commit()
+
+    metadata = Exporter.export_experiments_metadata(db_session=db_session)
+
+    assert metadata.version == aqueductcore.__version__
+    assert metadata.variant == AqueductVariant.CORE.value
+    assert len(metadata.users) == 1
+    assert metadata.users[0].uid == user_id
+    assert metadata.users[0].username == settings.default_username
+
+    # TODO: Add assertions for data equality.
+
+
+def test_get_dir_size():
+
+    with TemporaryDirectory() as tmpdirname:
+        total_size = 0
+        for dir_idx in range(10):
+            experiment_dir = os.path.join(tmpdirname, f"test_dir_{dir_idx}")
+            os.mkdir(experiment_dir)
+            for file_idx in range(10):
+                test_file_size = 100
+                test_file_name = f"test_file_{file_idx}"
+                test_file_path = os.path.join(experiment_dir, test_file_name)
+                test_data = bytes(bytearray(os.urandom(test_file_size)))
+                with open(test_file_path, mode="wb") as file_writer:
+                    file_writer.write(test_data)
+                total_size += test_file_size
+
+        assert Exporter._get_dir_size(tmpdirname) == total_size
+
+
+def test_export_artifact():
+
+    with TemporaryDirectory() as tmpdirname:
+        total_size = 0
+        test_files = {}
+        for dir_idx in range(10):
+            experiment_dir = os.path.join(tmpdirname, f"test_dir_{dir_idx}")
+            experiment_dir_in_tar = os.path.join(
+                tmpdirname, Exporter.EXPERIMENTS_BASE_DIR_NAME, f"test_dir_{dir_idx}"
+            )
+            os.mkdir(experiment_dir)
+            for file_idx in range(10):
+                test_file_size = 100
+                test_file_name = f"test_file_{file_idx}"
+                test_file_path = os.path.join(experiment_dir, test_file_name)
+                test_data = bytes(bytearray(os.urandom(test_file_size)))
+                test_files[os.path.join(experiment_dir_in_tar, test_file_name)] = test_data
+                with open(test_file_path, mode="wb") as file_writer:
+                    file_writer.write(test_data)
+                total_size += test_file_size
+
+        export_tarfile = BytesIO()
+        metadata_filename = "metadata.json"
+        test_files[os.path.join(tmpdirname, metadata_filename)] = "test".encode()
+        Exporter.export_artifact(
+            metadata="test".encode(),
+            output_fileobj=export_tarfile,
+            metadata_filename=metadata_filename,
+            experiments_root=tmpdirname,
+        )
+
+        export_tarfile.seek(0)
+        with tarfile.open(fileobj=export_tarfile, mode="r:gz") as tar:
+            for member in tar:
+                if member.isfile():
+                    assert os.path.join(tmpdirname, member.name) in list(test_files.keys())
+                    file = tar.extractfile(member)
+                    assert file is not None
+                    assert file.read() == test_files[os.path.join(tmpdirname, member.name)]

--- a/tests/unittests/cli/test_exporter.py
+++ b/tests/unittests/cli/test_exporter.py
@@ -71,7 +71,7 @@ def test_get_dir_size():
                     file_writer.write(test_data)
                 total_size += test_file_size
 
-        assert Exporter._get_dir_size(tmpdirname) == total_size
+        assert Exporter.get_dir_size(tmpdirname) == total_size
 
 
 def test_export_artifact():
@@ -98,8 +98,8 @@ def test_export_artifact():
         export_tarfile = BytesIO()
         test_files[os.path.join(tmpdirname, Exporter.METADATA_FILENAME)] = "test".encode()
         with tarfile.open(mode="w:gz", fileobj=export_tarfile) as tar:
-            Exporter.export_artifact(
-                metadata="test".encode(),
+            Exporter.export_archive(
+                metadata_bytes="test".encode(),
                 tar=tar,
                 experiments_root=tmpdirname,
             )

--- a/tests/unittests/cli/test_exporter.py
+++ b/tests/unittests/cli/test_exporter.py
@@ -71,7 +71,7 @@ def test_get_dir_size():
                     file_writer.write(test_data)
                 total_size += test_file_size
 
-        assert Exporter.get_dir_size(tmpdirname) == total_size
+        assert Exporter.get_size(tmpdirname) == total_size
 
 
 def test_export_artifact():

--- a/tests/unittests/cli/test_importer.py
+++ b/tests/unittests/cli/test_importer.py
@@ -1,0 +1,143 @@
+# pylint: skip-file
+
+import os
+import random
+import tarfile
+from datetime import datetime
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from typing import Dict, List
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import aqueductcore
+from aqueductcore.backend.models import orm
+from aqueductcore.backend.models.experiment import ExperimentCreate
+from aqueductcore.backend.settings import settings
+from aqueductcore.cli.exporter import Exporter
+from aqueductcore.cli.importer import Importer
+from aqueductcore.cli.models import AqueductData, AqueductVariant, Experiment, Tag, User
+
+
+def test_check_version_compatible():
+
+    max_rand = 100
+    assert (
+        Importer.check_version_compatible(
+            f"1.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+            f"2.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+        )
+        == False
+    )
+    assert (
+        Importer.check_version_compatible(
+            f"1.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+            f"1.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+        )
+        == True
+    )
+    for _ in range(1000):
+        major1 = random.randrange(0, 5)
+        major2 = random.randrange(0, 5)
+        res = Importer.check_version_compatible(
+            f"{major1}.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+            f"{major2}.{random.randrange(0,max_rand)}.{random.randrange(0,max_rand)}",
+        )
+        assert res == (True if major1 == major2 else False)
+
+
+def test_import_experiments_metadata(db_session: Session, experiments_data: List[ExperimentCreate]):
+
+    expected_metadata = AqueductData(
+        version=aqueductcore.__version__, variant=AqueductVariant.CORE, users=[]
+    )
+    for _ in range(10):  ## TODO
+        metauser = User(uuid=uuid4(), username=settings.default_username, experiments=[])
+
+        for experiment in experiments_data:
+            metauser.experiments.append(
+                Experiment(
+                    uuid=uuid4(),
+                    title=experiment.title,
+                    eid=str(uuid4()),
+                    description=experiment.description,
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                    tags=[Tag(key=item.key, name=item.name) for item in experiment.tags],
+                )
+            )
+        expected_metadata.users.append(metauser)
+
+    Importer.import_experiments_metadata(db_session=db_session, metadata=expected_metadata)
+
+    db_session.commit()  # needed to replicate autocommit feature session.
+
+    users_statement = select(orm.User)
+    db_users = db_session.execute(users_statement).scalars().all()
+
+    assert len(db_users) == len(expected_metadata.users)
+    for exp_user in expected_metadata.users:
+        user_res = [item for item in db_users if item.id == exp_user.uuid]
+        assert len(user_res) == 1
+        db_user = user_res[0]
+        assert db_user.username == exp_user.username
+        for exp_exp in exp_user.experiments:
+            exp_res = [item for item in db_user.experiments if item.id == exp_exp.uuid]
+            assert len(exp_res) == 1
+            db_experiment = exp_res[0]
+            assert db_experiment.alias == exp_exp.eid
+            assert db_experiment.created_at == exp_exp.created_at
+            assert db_experiment.updated_at == exp_exp.updated_at
+            assert db_experiment.title == exp_exp.title
+            assert db_experiment.description == exp_exp.description
+            assert {tag.key: tag.name for tag in db_experiment.tags} == {
+                tag.key: tag.name for tag in exp_exp.tags
+            }  # this assertion should be ok for pre-existing tags with different case.
+
+
+def test_import_artifact():
+
+    with TemporaryDirectory() as tmprootdir:
+        with TemporaryDirectory() as tmpdirname:
+            test_tarfile = BytesIO()
+            test_files = {}
+            with tarfile.open(mode="w:gz", fileobj=test_tarfile) as tar:
+                total_size = 0
+                for _ in range(10):
+                    eid = uuid4()
+                    experiment_dir = os.path.join(tmpdirname, f"{eid}")
+                    experiment_dir_in_tar = os.path.join(
+                        Exporter.EXPERIMENTS_BASE_DIR_NAME, f"{eid}"
+                    )
+                    os.mkdir(experiment_dir)
+                    for file_idx in range(10):
+                        test_file_size = 100
+                        test_file_name = f"test_file_{file_idx}"
+                        test_file_path = os.path.join(experiment_dir, test_file_name)
+                        test_data = bytes(bytearray(os.urandom(test_file_size)))
+                        test_files[
+                            os.path.join(
+                                tmprootdir,
+                                Exporter.EXPERIMENTS_BASE_DIR_NAME,
+                                f"{eid}",
+                                test_file_name,
+                            )
+                        ] = test_data
+                        with open(test_file_path, mode="wb") as file_writer:
+                            file_writer.write(test_data)
+                        total_size += test_file_size
+                    tar.add(
+                        name=experiment_dir,
+                        arcname=experiment_dir_in_tar,
+                    )
+
+            test_tarfile.seek(0)
+
+            with tarfile.open(fileobj=test_tarfile, mode="r:gz") as tar:
+                Importer.import_artifact(tar=tar, experiments_root=tmprootdir)
+
+                for filename, content in test_files.items():
+                    with open(filename, mode="rb") as file_reader:
+                        assert file_reader.read() == content

--- a/tests/unittests/cli/test_importer.py
+++ b/tests/unittests/cli/test_importer.py
@@ -120,7 +120,6 @@ def test_import_artifact():
                         test_files[
                             os.path.join(
                                 tmprootdir,
-                                Exporter.EXPERIMENTS_BASE_DIR_NAME,
                                 f"{eid}",
                                 test_file_name,
                             )
@@ -136,7 +135,7 @@ def test_import_artifact():
             test_tarfile.seek(0)
 
             with tarfile.open(fileobj=test_tarfile, mode="r:gz") as tar:
-                Importer.import_artifact(tar=tar, experiments_root=tmprootdir)
+                Importer.import_experiment_files(tar=tar, experiments_root=tmprootdir)
 
                 for filename, content in test_files.items():
                     with open(filename, mode="rb") as file_reader:


### PR DESCRIPTION
This PR adds the import and export modules to the CLI application for importing aqueduct artifacts that are previously exported. Tests are added to check the functionality. The following describes the importing behaviour in certain scenarios:

- When importing, if there is an existing experiment with the same experiment ID (aka alias), the import fails, outputting the conflicting experiments.
- When importing, if there are already existing conflicting tags, the existing ones will be used to be assigned to the imported experiment. This means the original display case (name field) will be preserved.
- When importing, if the are already existing conflicting users with the same user ID, the original username will be kept and the experiments will be assigned to the existing user. Conflicting user IDs means they are the same user as the user ID is a UUID.
- Due to the way the Linux file system and archiving works, the file’s last updated time will be reset to the time the files are extracted from the archive. If the original datetime is required by the user, the volume should be moved by the system administrator instead.

About the export module, the chosen compression method is gzip. Basic unit tests are added, but they will be improved in future PRs related to CLI and import functionality. The rest of the code is self-explanatory.