### PR TITLE
feat(enhanced-extension): add validation and dark theme support to extension modal

### DIFF
--- a/aqueductcore/frontend/src/__mocks__/ExtensionsDataMock.ts
+++ b/aqueductcore/frontend/src/__mocks__/ExtensionsDataMock.ts
@@ -1,3 +1,4 @@
+import { selected_experiment } from "__mocks__/queries/getExperimentByIdMock";
 import { ExtensionType } from "types/globalTypes";
 
 export const ExtensionsDataMock: ExtensionType[] = [
@@ -21,7 +22,7 @@ export const ExtensionsDataMock: ExtensionType[] = [
                     },
                     {
                         "dataType": "int",
-                        "defaultValue": null,
+                        "defaultValue": "20",
                         "description": "variable 2",
                         "displayName": "some display name",
                         "name": "var2",
@@ -29,7 +30,7 @@ export const ExtensionsDataMock: ExtensionType[] = [
                     },
                     {
                         "dataType": "float",
-                        "defaultValue": null,
+                        "defaultValue": "20.12",
                         "description": "variable 3",
                         "displayName": null,
                         "name": "var3",
@@ -37,7 +38,7 @@ export const ExtensionsDataMock: ExtensionType[] = [
                     },
                     {
                         "dataType": "experiment",
-                        "defaultValue": null,
+                        "defaultValue": selected_experiment.alias,
                         "description": "variable 4",
                         "displayName": null,
                         "name": "var4",
@@ -45,7 +46,7 @@ export const ExtensionsDataMock: ExtensionType[] = [
                     },
                     {
                         "dataType": "textarea",
-                        "defaultValue": null,
+                        "defaultValue": "some multiline\ntext",
                         "description": "variable 5 multiline",
                         "displayName": null,
                         "name": "var5",

--- a/aqueductcore/frontend/src/__mocks__/ExtensionsDataMock.ts
+++ b/aqueductcore/frontend/src/__mocks__/ExtensionsDataMock.ts
@@ -1,4 +1,4 @@
-import { selected_experiment } from "__mocks__/queries/getExperimentByIdMock";
+import { selected_experiment } from "__mocks__/queries/experiment/getExperimentByIdMock";
 import { ExtensionType } from "types/globalTypes";
 
 export const ExtensionsDataMock: ExtensionType[] = [

--- a/aqueductcore/frontend/src/__mocks__/constants.ts
+++ b/aqueductcore/frontend/src/__mocks__/constants.ts
@@ -5,3 +5,4 @@ export const experimentsSearchString = "Rabi";
 // Mutation test constants
 export const updatedTitle = "New updated title";
 export const updatedDescription = "New updated details";
+export const logFileName = "log_file.log"

--- a/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
+++ b/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
@@ -1,7 +1,8 @@
-import { EXECUTE_EXTENSION } from "API/graphql/mutations/extension/executeExtension";
 import { selected_experiment } from "__mocks__/queries/experiment/getExperimentByIdMock";
+import { EXECUTE_EXTENSION } from "API/graphql/mutations/extension/executeExtension";
 
 import { ExtensionsDataMock } from "__mocks__/ExtensionsDataMock";
+import { logFileName } from "__mocks__/constants";
 
 // warning: This is not based on the real mock it's just no change and submit mode of the form
 
@@ -37,6 +38,7 @@ export const executeExtension_mock = {
                         "stderr": "",
                         // "stdout": `var1=1\nvar2=null\nvar3=null\nvar4=${selected_experiment.alias}\nvar5=null\nvar6=1\nvar7=string three\ndummykey=dummyvalue\n`,
                         "stdout": `${params.map(param => param.join('=')).join('\n')}\ndummykey=dummyvalue\n`,
+                        "logFile": logFileName,
                         "__typename": "ExtensionExecutionResult"
                     }
                 }

--- a/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
+++ b/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
@@ -1,10 +1,7 @@
 import { selected_experiment } from "__mocks__/queries/experiment/getExperimentByIdMock";
 import { EXECUTE_EXTENSION } from "API/graphql/mutations/extension/executeExtension";
-
 import { ExtensionsDataMock } from "__mocks__/ExtensionsDataMock";
 import { logFileName } from "__mocks__/constants";
-
-// warning: This is not based on the real mock it's just no change and submit mode of the form
 
 const extensionName = ExtensionsDataMock[0].name
 const actionName = ExtensionsDataMock[0].actions[0].name
@@ -36,7 +33,6 @@ export const executeExtension_mock = {
                     "executeExtension": {
                         "returnCode": 0,
                         "stderr": "",
-                        // "stdout": `var1=1\nvar2=null\nvar3=null\nvar4=${selected_experiment.alias}\nvar5=null\nvar6=1\nvar7=string three\ndummykey=dummyvalue\n`,
                         "stdout": `${params.map(param => param.join('=')).join('\n')}\ndummykey=dummyvalue\n`,
                         "logFile": logFileName,
                         "__typename": "ExtensionExecutionResult"

--- a/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
+++ b/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
@@ -1,24 +1,33 @@
 import { EXECUTE_EXTENSION } from "API/graphql/mutations/extension/executeExtension";
 import { selected_experiment } from "__mocks__/queries/experiment/getExperimentByIdMock";
 
+import { ExtensionsDataMock } from "__mocks__/ExtensionsDataMock";
+
 // warning: This is not based on the real mock it's just no change and submit mode of the form
-export const executeExtension_mock = {
+
+const extensionName = ExtensionsDataMock[0].name
+const actionName = ExtensionsDataMock[0].actions[0].name
+const parameters = ExtensionsDataMock[0].actions[0].parameters
+
+const params = [
+    ["var1", parameters[0].defaultValue],
+    ["var2", parameters[1].defaultValue],
+    ["var3", parameters[2].defaultValue],
+    ["var4", `${selected_experiment.alias}`],
+    ["var5", parameters[4].defaultValue],
+    ["var6", parameters[5].defaultValue],
+    ["var7", parameters[6].defaultValue]
+]
+
+export const executeExperiment_mock = {
     success: [
         {
             request: {
                 query: EXECUTE_EXTENSION,
                 variables: {
-                    "extension": "Dummy extension",
-                    "action": "echo",
-                    "params": [
-                        ["var1", "1"],
-                        ["var2", null],
-                        ["var3", null],
-                        ["var4", `${selected_experiment.alias}`],
-                        ["var5", null],
-                        ["var6", "1"],
-                        ["var7", "string three"]
-                    ]
+                    "extension": extensionName,
+                    "action": actionName,
+                    "params": params
                 }
             },
             result: {
@@ -26,8 +35,8 @@ export const executeExtension_mock = {
                     "executeExtension": {
                         "returnCode": 0,
                         "stderr": "",
-                        "stdout": `var1=1\nvar2=null\nvar3=null\nvar4=${selected_experiment.alias}\nvar5=null\nvar6=1\nvar7=string three\ndummykey=dummyvalue\n`,
-                        "logFile": "log_file.log",
+                        // "stdout": `var1=1\nvar2=null\nvar3=null\nvar4=${selected_experiment.alias}\nvar5=null\nvar6=1\nvar7=string three\ndummykey=dummyvalue\n`,
+                        "stdout": `${params.map(param => param.join('=')).join('\n')}\ndummykey=dummyvalue\n`,
                         "__typename": "ExtensionExecutionResult"
                     }
                 }

--- a/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
+++ b/aqueductcore/frontend/src/__mocks__/mutations/extension/executeExtension.tsx
@@ -19,7 +19,7 @@ const params = [
     ["var7", parameters[6].defaultValue]
 ]
 
-export const executeExperiment_mock = {
+export const executeExtension_mock = {
     success: [
         {
             request: {

--- a/aqueductcore/frontend/src/__mocks__/queries/experiment/getExperimentByIdMock.tsx
+++ b/aqueductcore/frontend/src/__mocks__/queries/experiment/getExperimentByIdMock.tsx
@@ -1,7 +1,7 @@
 import { GET_EXPERIMENT_BY_ID } from "API/graphql/queries/experiment/getExperimentById";
 import { ExperimentsDataMock } from "__mocks__/ExperimentsDataMock";
 
-export const selected_experiment = ExperimentsDataMock[0]
+export const selected_experiment = ExperimentsDataMock[0];
 
 const request = {
     query: GET_EXPERIMENT_BY_ID,

--- a/aqueductcore/frontend/src/__tests__/Extensions.test.tsx
+++ b/aqueductcore/frontend/src/__tests__/Extensions.test.tsx
@@ -7,6 +7,7 @@ import { ExtensionsDataMock } from "__mocks__/ExtensionsDataMock";
 import { ExtensionParameterDataTypes } from "constants/constants";
 import ExperimentDetailsPage from "pages/ExperimentDetailsPage";
 import AppContextAQDMock from "__mocks__/AppContextAQDMock";
+import { logFileName } from "__mocks__/constants";
 
 function ExtensionIncludedComponent() {
     return (
@@ -97,7 +98,7 @@ test("submit the form and success modal and file selection", async () => {
     const successModal = await findByText("Execution finished successfully")
     expect(successModal).toBeInTheDocument()
 
-    const file_name_items = await findAllByText('log_file.log')
+    const file_name_items = await findAllByText(logFileName)
     expect(file_name_items).toHaveLength(2)
     //1- file being selected in the <Explorer />
     expect(file_name_items[0].parentNode).toHaveClass('Mui-selected')

--- a/aqueductcore/frontend/src/components/atoms/ExperimentField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/ExperimentField/index.tsx
@@ -5,7 +5,7 @@ import { ExtensionFieldBase } from "types/globalTypes";
 
 const ExperimentBox = styled(Box)`
   border: 1px solid ${({ theme }) => theme.palette.neutral.main};
-  background-color: ${({ theme }) => theme.palette.grey[200]};;
+  background-color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[200]};
   width: calc(100% - ${(props) => props.theme.spacing(1)});
   border-radius: ${(props) => props.theme.spacing(0.5)};
   padding: ${(props) => props.theme.spacing(1)};

--- a/aqueductcore/frontend/src/components/atoms/FileField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/FileField/index.tsx
@@ -2,7 +2,7 @@ import { Autocomplete, AutocompleteProps, Box, Grid, InputAdornment, TextField, 
 
 import { FieldDescription, FieldTitle, FieldType, InputFieldHint } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { useGetExperimentFilesById } from "API/graphql/queries/experiment/getExperimentFilesById";
-import { ExtensionFieldBase } from "types/globalTypes";
+import { ExtensionFieldBase, WithOptional } from "types/globalTypes";
 
 const FileInput = styled(TextField)`
   resize: none;
@@ -15,7 +15,7 @@ const FileInput = styled(TextField)`
 
 interface FileFieldProps extends ExtensionFieldBase {
   experimentIdentifier: string;
-  fileFieldProps?: AutocompleteProps<string, false, true, false>;
+  fileFieldProps?: WithOptional<WithOptional<AutocompleteProps<string, false, true, false>, 'options'>, 'renderInput'>;
 }
 
 export function FileField({

--- a/aqueductcore/frontend/src/components/atoms/FileField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/FileField/index.tsx
@@ -1,6 +1,6 @@
-import { Autocomplete, AutocompleteProps, Box, Grid, TextField, styled } from "@mui/material";
+import { Autocomplete, AutocompleteProps, Box, Grid, InputAdornment, TextField, styled } from "@mui/material";
 
-import { FieldDescription, FieldTitle, FieldType } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { FieldDescription, FieldTitle, FieldType, InputFieldHint } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { useGetExperimentFilesById } from "API/graphql/queries/experiment/getExperimentFilesById";
 import { ExtensionFieldBase } from "types/globalTypes";
 
@@ -59,7 +59,17 @@ export function FileField({
               size="small"
               forcePopupIcon={false}
               options={experimentFilesList}
-              renderInput={(params) => <FileInput {...params} />}
+              renderInput={(params) => <FileInput
+                {...params}
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <InputFieldHint>file</InputFieldHint>
+                    </InputAdornment>
+                  ),
+                }}
+              />}
             />
           </Box>
         </Grid>

--- a/aqueductcore/frontend/src/components/atoms/FloatField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/FloatField/index.tsx
@@ -1,6 +1,6 @@
-import { Box, Grid, TextField, TextFieldProps, styled } from "@mui/material";
+import { Box, Grid, InputAdornment, TextField, TextFieldProps, styled } from "@mui/material";
 
-import { FieldDescription, FieldTitle, FieldType } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { FieldDescription, FieldTitle, FieldType, InputFieldHint, RequiredFieldIndicator } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { ExtensionFieldBase } from "types/globalTypes";
 
 const FloatInput = styled(TextField)`
@@ -36,7 +36,9 @@ export function FloatField({
     <Box>
       <Grid container sx={{ px: 2, py: 1.5 }}>
         <Grid item xs={6}>
-          <FieldTitle>{title}</FieldTitle><FieldType>{field}</FieldType>
+          <FieldTitle>{title}</FieldTitle>
+          <RequiredFieldIndicator>*</RequiredFieldIndicator>
+          <FieldType>{field}</FieldType>
           <Box sx={{ p: 1, pr: 2 }}>
             <FloatInput
               {...floatFieldProps}
@@ -44,6 +46,11 @@ export function FloatField({
               size="small"
               title={field}
               defaultValue={defaultValue}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">
+                  <InputFieldHint>float</InputFieldHint>
+                </InputAdornment>,
+              }}
             />
           </Box>
         </Grid>

--- a/aqueductcore/frontend/src/components/atoms/IntegerField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/IntegerField/index.tsx
@@ -1,6 +1,6 @@
-import { Box, Grid, TextField, TextFieldProps, styled } from "@mui/material";
+import { Box, Grid, InputAdornment, TextField, TextFieldProps, styled } from "@mui/material";
 
-import { FieldDescription, FieldTitle, FieldType } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { FieldDescription, FieldTitle, FieldType, InputFieldHint, RequiredFieldIndicator } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { ExtensionFieldBase } from "types/globalTypes";
 
 const IntegerInput = styled(TextField)`
@@ -43,7 +43,9 @@ export function IntegerField({
     <Box>
       <Grid container sx={{ px: 2, py: 1.5 }}>
         <Grid item xs={6}>
-          <FieldTitle>{title}</FieldTitle><FieldType>{field}</FieldType>
+          <FieldTitle>{title}</FieldTitle>
+          <RequiredFieldIndicator>*</RequiredFieldIndicator>
+          <FieldType>{field}</FieldType>
           <Box sx={{ p: 1, pr: 2 }}>
             <IntegerInput
               {...integerFieldProps}
@@ -52,7 +54,12 @@ export function IntegerField({
               size="small"
               defaultValue={defaultValue}
               onKeyDown={handleKeyDown}
-              InputProps={{ inputProps: { step: 1, inputMode: 'numeric', pattern: '[0-9]*' } }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">
+                  <InputFieldHint>int</InputFieldHint>
+                </InputAdornment>,
+                inputProps: { step: 1, inputMode: 'numeric', pattern: '[0-9]*' }
+              }}
             />
           </Box>
         </Grid>

--- a/aqueductcore/frontend/src/components/atoms/SelectField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/SelectField/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Select, Grid, styled, MenuItem, SelectProps } from "@mui/material";
 
-import { FieldDescription, FieldTitle, FieldType } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { FieldDescription, FieldTitle, FieldType, RequiredFieldIndicator } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { ExtensionFieldBase } from "types/globalTypes";
 
 const DropDown = styled(Select)`
@@ -27,7 +27,9 @@ export function SelectField({
     <Box>
       <Grid container sx={{ px: 2, py: 1.5 }}>
         <Grid item xs={6}>
-          <FieldTitle>{title}</FieldTitle><FieldType>{field}</FieldType>
+          <FieldTitle>{title}</FieldTitle>
+          <RequiredFieldIndicator>*</RequiredFieldIndicator>
+          <FieldType>{field}</FieldType>
           <Box sx={{ p: 1 }}>
             <DropDown
               title={field}

--- a/aqueductcore/frontend/src/components/atoms/TextAreaField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/TextAreaField/index.tsx
@@ -1,18 +1,20 @@
 import { Box, Grid, TextareaAutosize, TextareaAutosizeProps, styled } from "@mui/material";
 
-import { FieldDescription, FieldTitle, FieldType } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { FieldDescription, FieldTitle, FieldType, RequiredFieldIndicator } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
 import { ExtensionFieldBase } from "types/globalTypes";
 
 const TextAreaInput = styled(TextareaAutosize)`
-  resize: none;
   width: 100%;
+  min-width: 100%;
+  max-width: 100%;
+  resize: auto;
   border-width: 1px;
   border-color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[400]};
   background-color: transparent;
   font-size: 0.9rem;
   line-height: ${(props) => props.theme.spacing(2.5)};
   border-radius: ${(props) => props.theme.spacing(0.5)};
-  min-height: ${(props) => props.theme.spacing(3)};
+  min-height: ${(props) => props.theme.spacing(5)};
   padding: ${(props) => props.theme.spacing(1)} ${(props) => props.theme.spacing(1.5)};
   
   &:focus {
@@ -38,7 +40,9 @@ export function TextAreaField({
     <Box>
       <Grid container sx={{ px: 2, py: 1.5 }}>
         <Grid item xs={6}>
-          <FieldTitle>{title}</FieldTitle><FieldType>{field}</FieldType>
+          <FieldTitle>{title}</FieldTitle>
+          <RequiredFieldIndicator>*</RequiredFieldIndicator>
+          <FieldType>{field}</FieldType>
           <Box sx={{ p: 1, pr: 2 }}>
             <TextAreaInput
               title={field}

--- a/aqueductcore/frontend/src/components/atoms/TextAreaField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/TextAreaField/index.tsx
@@ -9,9 +9,13 @@ const TextAreaInput = styled(TextareaAutosize)`
   max-width: 100%;
   resize: auto;
   border-width: 1px;
-  border-color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[400]};
+  border-color: ${({ theme }) => theme.palette.neutral.main};
   background-color: transparent;
-  font-size: 0.9rem;
+  font-size: 1rem;
+  color: ${(props) =>
+    props.theme.palette.mode === "dark"
+      ? props.theme.palette.common.white
+      : props.theme.palette.common.black};
   line-height: ${(props) => props.theme.spacing(2.5)};
   border-radius: ${(props) => props.theme.spacing(0.5)};
   min-height: ${(props) => props.theme.spacing(5)};

--- a/aqueductcore/frontend/src/components/atoms/TextInputField/TextInputField.test.tsx
+++ b/aqueductcore/frontend/src/components/atoms/TextInputField/TextInputField.test.tsx
@@ -1,0 +1,25 @@
+import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/react";
+
+import AppContextAQDMock from "__mocks__/AppContextAQDMock";
+import { TextInputField } from "components/atoms/TextInputField";
+
+test("only support float values in float field", async () => {
+    const { getByTitle } = render(
+        <AppContextAQDMock>
+            <TextInputField
+                title="text_field"
+                field="text_field"
+                description="Description of float field"
+                defaultValue="abc123"
+            />
+        </AppContextAQDMock>
+    );
+
+    const textInputTitle = await getByTitle("text_field");
+    expect(textInputTitle).toBeInTheDocument();
+
+    const textInputField = textInputTitle.children[0].children[0];
+    await userEvent.type(textInputField, "4@£$5.qtkis6cjas")
+    expect(textInputField).toHaveValue("abc1234@£$5.qtkis6cjas"); 
+});

--- a/aqueductcore/frontend/src/components/atoms/TextInputField/TextInputField.test.tsx
+++ b/aqueductcore/frontend/src/components/atoms/TextInputField/TextInputField.test.tsx
@@ -4,13 +4,13 @@ import { render } from "@testing-library/react";
 import AppContextAQDMock from "__mocks__/AppContextAQDMock";
 import { TextInputField } from "components/atoms/TextInputField";
 
-test("only support float values in float field", async () => {
+test("normal text input field", async () => {
     const { getByTitle } = render(
         <AppContextAQDMock>
             <TextInputField
                 title="text_field"
                 field="text_field"
-                description="Description of float field"
+                description="Description of textInputField"
                 defaultValue="abc123"
             />
         </AppContextAQDMock>

--- a/aqueductcore/frontend/src/components/atoms/TextInputField/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/TextInputField/index.tsx
@@ -1,0 +1,57 @@
+import { Box, Grid, InputAdornment, TextField, TextFieldProps, styled } from "@mui/material";
+
+import { FieldDescription, FieldTitle, FieldType, InputFieldHint, RequiredFieldIndicator } from "components/atoms/sharedStyledComponents/ExtensionInputFields"
+import { ExtensionFieldBase } from "types/globalTypes";
+
+const TextFieldInput = styled(TextField)`
+  resize: none;
+  width: 100%;
+  border-width: 1px;
+  border-color: ${({ theme }) => theme.palette.neutral.main};
+  padding: 0;
+  font-size: 0.9rem;
+  line-height: ${(props) => props.theme.spacing(2.5)};
+  border-radius: ${(props) => props.theme.spacing(0.5)};
+  min-height: ${(props) => props.theme.spacing(3)};
+`;
+
+interface TextInputFieldProps extends ExtensionFieldBase {
+  defaultValue?: string;
+  textFieldProps?: TextFieldProps
+}
+
+export function TextInputField({
+  title,
+  field,
+  description,
+  defaultValue,
+  textFieldProps
+}: TextInputFieldProps) {
+  return (
+    <Box>
+      <Grid container sx={{ px: 2, py: 1.5 }}>
+        <Grid item xs={6}>
+          <FieldTitle>{title}</FieldTitle>
+          <RequiredFieldIndicator>*</RequiredFieldIndicator>
+          <FieldType>{field}</FieldType>
+          <Box sx={{ p: 1, pr: 2 }}>
+            <TextFieldInput
+              {...textFieldProps}
+              size="small"
+              title={field}
+              defaultValue={defaultValue}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">
+                  <InputFieldHint>string</InputFieldHint>
+                </InputAdornment>,
+              }}
+            />
+          </Box>
+        </Grid>
+        <Grid item xs={6}>
+          <FieldDescription sx={{ pl: 2 }}>{description}</FieldDescription>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/aqueductcore/frontend/src/components/atoms/sharedStyledComponents/ExtensionInputFields/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/sharedStyledComponents/ExtensionInputFields/index.tsx
@@ -25,8 +25,8 @@ export const FieldType = styled(Typography)`
 export const FieldDescription = styled(Typography)`
   font-size: 0.8rem;
   font-style: italic;
-  border-left: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.common.white : theme.palette.grey[600]};
-  color: #555;
+  border-left: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[400] : theme.palette.grey[800]};
+  color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[400] : theme.palette.grey[800]};
   height: 100%;
 `;
 

--- a/aqueductcore/frontend/src/components/atoms/sharedStyledComponents/ExtensionInputFields/index.tsx
+++ b/aqueductcore/frontend/src/components/atoms/sharedStyledComponents/ExtensionInputFields/index.tsx
@@ -7,6 +7,14 @@ export const FieldTitle = styled(Typography)`
     margin-right: ${(props) => props.theme.spacing(0.5)};
 `;
 
+export const RequiredFieldIndicator = styled(Typography)`
+    font-size: 0.3;
+    font-weight: bold;
+    display: inline;
+    color: red;
+    margin-right: ${(props) => props.theme.spacing(1)};
+`;
+
 export const FieldType = styled(Typography)`
     font-size: 0.8rem;
     display: inline;
@@ -17,7 +25,12 @@ export const FieldType = styled(Typography)`
 export const FieldDescription = styled(Typography)`
   font-size: 0.8rem;
   font-style: italic;
-  border-left: 2px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.common.white : theme.palette.grey[600]};
+  border-left: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.common.white : theme.palette.grey[600]};
   color: #555;
   height: 100%;
+`;
+
+export const InputFieldHint = styled(Typography)`
+  font-size: 0.8rem;
+  font-family: monospace;
 `;

--- a/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
@@ -18,7 +18,7 @@ const Container = styled(Box)`
     height: 551px;
     padding: 0 ${(props) => props.theme.spacing(1)};
     overflow-y: auto;
-    `;
+`;
 
 interface ActionFormProps {
     selectedAction?: ExtensionActionType;
@@ -131,10 +131,10 @@ function ActionForm({
                                     description={parameterInfo?.description || ""}
                                     field={parameterInfo.name}
                                     experimentIdentifier={experimentIdentifier || ""}
-                                    // fileFieldProps={{
-                                    //     value: inputParams.find((item) => item.name === parameterInfo.name)?.value ?? '',
-                                    //     onChange: ((e) => setInputParams([...inputParams.filter(param => param.name !== parameterInfo.name), { name: parameterInfo.name, value: String(e.target.value) }]))
-                                    // }}
+                                    fileFieldProps={{
+                                        value: inputParams.find((item) => item.name === parameterInfo.name)?.value ?? '',
+                                        onChange: ((_, value) => setInputParams([...inputParams.filter(param => param.name !== parameterInfo.name), { name: parameterInfo.name, value: value }]))
+                                    }}
                                 />
                             </>}
                         </Box>

--- a/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
@@ -12,9 +12,10 @@ import { SelectField } from "components/atoms/SelectField";
 import { ExtensionActionType } from "types/globalTypes";
 import { FloatField } from "components/atoms/FloatField";
 import { client } from "API/apolloClientConfig";
+import { FileField } from "components/atoms/FileField";
 
 const Container = styled(Box)`
-    height: 557px;
+    height: 551px;
     padding: 0 ${(props) => props.theme.spacing(1)};
     overflow-y: auto;
     `;
@@ -41,6 +42,7 @@ function ActionForm({
             },
         },
     });
+
     return (
         <>
             <Container>
@@ -121,6 +123,18 @@ function ActionForm({
                                         value: inputParams.find((item) => item.name === parameterInfo.name)?.value ?? '',
                                         onChange: ((e) => setInputParams([...inputParams.filter(param => param.name !== parameterInfo.name), { name: parameterInfo.name, value: String(e.target.value) }]))
                                     }}
+                                />
+                            </>}
+                            {parameterInfo.dataType == ExtensionParameterDataTypes.FILE && <>
+                                <FileField
+                                    title={parameterInfo?.displayName || ""}
+                                    description={parameterInfo?.description || ""}
+                                    field={parameterInfo.name}
+                                    experimentIdentifier={experimentIdentifier || ""}
+                                    // fileFieldProps={{
+                                    //     value: inputParams.find((item) => item.name === parameterInfo.name)?.value ?? '',
+                                    //     onChange: ((e) => setInputParams([...inputParams.filter(param => param.name !== parameterInfo.name), { name: parameterInfo.name, value: String(e.target.value) }]))
+                                    // }}
                                 />
                             </>}
                         </Box>

--- a/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ActionForm/index.tsx
@@ -13,6 +13,7 @@ import { ExtensionActionType } from "types/globalTypes";
 import { FloatField } from "components/atoms/FloatField";
 import { client } from "API/apolloClientConfig";
 import { FileField } from "components/atoms/FileField";
+import { TextInputField } from "components/atoms/TextInputField";
 
 const Container = styled(Box)`
     height: 551px;
@@ -50,11 +51,11 @@ function ActionForm({
                     {selectedAction?.parameters.map(parameterInfo => (
                         <Box key={parameterInfo.name}>
                             {parameterInfo.dataType == ExtensionParameterDataTypes.STR && <>
-                                <TextAreaField
+                                <TextInputField
                                     title={parameterInfo?.displayName || ""}
                                     description={parameterInfo?.description || ""}
                                     field={parameterInfo.name}
-                                    textareaFieldProps={{
+                                    textFieldProps={{
                                         value: inputParams.find((item) => item.name === parameterInfo.name)?.value ?? '',
                                         onChange: ((e) => setInputParams([...inputParams.filter(param => param.name !== parameterInfo.name), { name: parameterInfo.name, value: e.target.value }]))
                                     }}

--- a/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
@@ -17,12 +17,12 @@ const HiddenRadio = styled(Radio)`
     display: none;
 `;
 
-const ActionHeader = styled(Grid)<{ $isselected?: boolean }>`
+const ActionHeader = styled(Grid, {shouldForwardProp: (prop) => prop !== "$isselected"})<{$isselected: boolean}>`
     padding: 0 ${(props) => props.theme.spacing(1.5)};
-    background-color: ${({ theme, $isselected }) => $isselected ? theme.palette.primary.main : theme.palette.grey[500]};
-    border-bottom: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[300]};
+    background-color: ${({ theme, $isselected }) => $isselected ? theme.palette.primary.main : theme.palette.background.default};
+    border-bottom: 1px solid ${({ theme }) => theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[300]};
     border-radius: ${(props) => props.theme.spacing(0.5)} ${(props) => props.theme.spacing(0.5)} 0 0;
-    &:after{clear: both;display: block;content: "";}
+    &:after{clear: both;display: block;content: '';}
 `;
 
 const ActionsFormControl = styled(FormControl)`
@@ -53,7 +53,7 @@ const ActionDescription = styled(Typography)`
     background-color: ${(props) =>
         props.theme.palette.mode === "dark"
         ? props.theme.palette.background.card
-        : props.theme.palette.grey[200]};
+        : props.theme.palette.common.white};
     border-radius: 0 0 ${(props) => props.theme.spacing(0.5)} ${(props) => props.theme.spacing(0.5)};
 `;
 

--- a/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
@@ -17,9 +17,9 @@ const HiddenRadio = styled(Radio)`
     display: none;
 `;
 
-const ActionHeader = styled(Grid)<{ $isSelected?: boolean }>`
+const ActionHeader = styled(Grid)<{ $isselected?: boolean }>`
     padding: 0 ${(props) => props.theme.spacing(1.5)};
-    background-color: ${({ theme, $isSelected }) => $isSelected ? theme.palette.primary.main : theme.palette.grey[500]};
+    background-color: ${({ theme, $isselected }) => $isselected ? theme.palette.primary.main : theme.palette.grey[500]};
     border-bottom: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[300]};
     border-radius: ${(props) => props.theme.spacing(0.5)} ${(props) => props.theme.spacing(0.5)} 0 0;
     &:after{clear: both;display: block;content: "";}
@@ -96,7 +96,7 @@ function ExtensionActions({
                             control={<HiddenRadio />}
                             label={
                                 <ExtensionActionBox>
-                                    <ActionHeader $isSelected={selectedAction?.name == ActionInfo.name}>
+                                    <ActionHeader $isselected={selectedAction?.name == ActionInfo.name}>
                                         <ActionName>{ActionInfo.name}</ActionName>
                                         <ActionCheckbox>
                                             <Radio

--- a/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
+++ b/aqueductcore/frontend/src/components/molecules/ExtensionActions/index.tsx
@@ -5,7 +5,7 @@ import { ExtensionActionType, ExtensionType } from "types/globalTypes";
 
 const ExtensionActionBox = styled(Box)`
     width: 100%;
-    border: 1px solid ${({ theme }) => theme.palette.grey[300]};
+    border: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[300]};
     border-radius: ${(props) => props.theme.spacing(0.5)};
 `;
 
@@ -17,10 +17,10 @@ const HiddenRadio = styled(Radio)`
     display: none;
 `;
 
-const ActionHeader = styled(Grid)`
+const ActionHeader = styled(Grid)<{ $isSelected?: boolean }>`
     padding: 0 ${(props) => props.theme.spacing(1.5)};
-    background-color: ${({ theme }) => theme.palette.grey[500]};
-    border-bottom: 1px solid ${({ theme }) => theme.palette.grey[300]};
+    background-color: ${({ theme, $isSelected }) => $isSelected ? theme.palette.primary.main : theme.palette.grey[500]};
+    border-bottom: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[300]};
     border-radius: ${(props) => props.theme.spacing(0.5)} ${(props) => props.theme.spacing(0.5)} 0 0;
     &:after{clear: both;display: block;content: "";}
 `;
@@ -50,7 +50,10 @@ const ActionCheckbox = styled(Box)`
 const ActionDescription = styled(Typography)`
     font-size: 0.8rem;
     padding: ${(props) => props.theme.spacing(0.75)} ${(props) => props.theme.spacing(1.5)};
-    background-color: ${(props) => props.theme.palette.common.white};
+    background-color: ${(props) =>
+        props.theme.palette.mode === "dark"
+        ? props.theme.palette.background.card
+        : props.theme.palette.grey[200]};
     border-radius: 0 0 ${(props) => props.theme.spacing(0.5)} ${(props) => props.theme.spacing(0.5)};
 `;
 
@@ -93,7 +96,7 @@ function ExtensionActions({
                             control={<HiddenRadio />}
                             label={
                                 <ExtensionActionBox>
-                                    <ActionHeader style={{ backgroundColor: selectedAction?.name == ActionInfo.name ? "#3dcbda" : "transparent" }}>
+                                    <ActionHeader $isSelected={selectedAction?.name == ActionInfo.name}>
                                         <ActionName>{ActionInfo.name}</ActionName>
                                         <ActionCheckbox>
                                             <Radio

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -114,9 +114,8 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
     const selectedExtensionItem = extensions?.find(extension => extension.name === selectedExtension)
     const [selectedAction, setSelectedAction] = useState<ExtensionActionType | undefined>();
     const { loading, mutate } = useExecuteExtension();
-    const [inputParams, setInputParams] = useState<Array<actionInExtensionsType>>()
-    const { setSelectedFile } = useContext(FileSelectStateContext)
-    const [executeExtensionEnabled, setExecuteExtensionEnabled] = useState(false);
+    const [inputParams, setInputParams] = useState<Array<actionInExtensionsType>>();
+    const { setSelectedFile } = useContext(FileSelectStateContext);
 
     useEffect(() => {
         setInputParams(selectedAction?.parameters.map(
@@ -127,20 +126,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
         )
     }, [selectedExtension, selectedAction])
 
-    useEffect(() => {
-        let enableExecutionUpdate: boolean = true;
-        enableExecutionUpdate = !inputParams?.some(param => {
-            const paramElement = selectedAction?.parameters?.find(inputParam => inputParam.name === param.name);
-            return (
-                (paramElement?.dataType === ExtensionParameterDataTypes.STR && param.value === "") ||
-                (paramElement?.dataType === ExtensionParameterDataTypes.INT && param.value === "") ||
-                (paramElement?.dataType === ExtensionParameterDataTypes.FLOAT && param.value === "") ||
-                (paramElement?.dataType === ExtensionParameterDataTypes.SELECT && param.value === "") ||
-                (paramElement?.dataType === ExtensionParameterDataTypes.TEXTAREA && param.value === "")
-            );
-        });
-        setExecuteExtensionEnabled(enableExecutionUpdate);
-    }, [inputParams, selectedAction])
+    const isExtensionExexutable = inputParams?.every(param => param.value);
 
     async function handleOnCompletedExtensionExecution(executeExtension: EXECUTE_EXTENSION_TYPE) {
         handleClose()
@@ -222,7 +208,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
                                 variant="contained"
                                 onClick={() => handleExecuteExtension()}
                                 title='run_extension'
-                                disabled={!executeExtensionEnabled}
+                                disabled={!isExtensionExexutable}
                             >
                                 Run Extension
                             </RunExtension>

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -224,7 +224,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
                                 title='run_extension'
                                 disabled={!executeExtensionEnabled}
                             >
-                                Run Extention
+                                Run Extension
                             </RunExtension>
                         </Box>
                     </ModalFooter>

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -29,16 +29,18 @@ const ModalContainer = styled(Box)`
     left: 50%;
     transform: translate(-50%, -50%);
     width: 1080px;
-    background-color: ${(props) => props.theme.palette.background.default};
     box-shadow: 24;
     border-radius: ${(props) => props.theme.spacing(1)};
 `;
 
 const ModalHeader = styled(Grid)`
-    background-color: ${({ theme }) => theme.palette.grey[300]};
+    background-color: ${(props) =>
+    props.theme.palette.mode === "dark"
+      ? props.theme.palette.common.black
+      : props.theme.palette.grey[300]};
     border-radius: ${(props) => props.theme.spacing(1)} ${(props) => props.theme.spacing(1)} 0 0;
     line-height: 3.25rem;
-    border-bottom: 1px solid ${({ theme }) => theme.palette.grey[400]};
+    border-bottom: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[400]};
     padding: 0 ${(props) => props.theme.spacing(2)};
 `;
 
@@ -73,13 +75,23 @@ const AuthorName = styled(Typography)`
 const ModalOptionsGrid = styled(Grid)`
     height: 620px;
     background-color: ${({ theme }) => theme.palette.grey[200]};
+    background-color: ${(props) =>
+    props.theme.palette.mode === "dark"
+      ? props.theme.palette.grey[900]
+      : props.theme.palette.grey[200]};
     border-right: 1px solid rgba(0,0,0,0.3);
     padding: ${(props) => props.theme.spacing(2.5)} ${(props) => props.theme.spacing(3)};
 `;
 
+const RunExtension = styled(Button)`
+    background-color: ${(props) => props.theme.palette.primary.main};
+`;
 
 const ModalStepGrid = styled(Grid)`
-    background-color: ${(props) => props.theme.palette.common.white};
+    background-color: ${(props) =>
+    props.theme.palette.mode === "dark"
+      ? props.theme.palette.background.card
+      : props.theme.palette.common.white};
     height: 620px;
     position: relative;
 `;
@@ -89,7 +101,7 @@ const ModalFooter = styled(Box)`
     bottom: 0;
     left: 0;
     width: 100%;
-    border-top: 1px solid ${({ theme }) => theme.palette.grey[400]};
+    border-top: 1px solid ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[400]};
     padding: ${(props) => props.theme.spacing(2)} ${(props) => props.theme.spacing(3)};
 `;
 
@@ -206,14 +218,14 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
                     <ModalFooter>
                         <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                             {loading ? <CircularProgress size={36} sx={{ mr: 3 }} /> : null}
-                            <Button
+                            <RunExtension
                                 variant="contained"
                                 onClick={() => handleExecuteExtension()}
                                 title='run_extension'
                                 disabled={!executeExtensionEnabled}
                             >
-                                Run Extension
-                            </Button>
+                                Run Extention
+                            </RunExtension>
                         </Box>
                     </ModalFooter>
                 </Grid>


### PR DESCRIPTION
## Changes
* Add field hints to show type of data to be filled.
* Disabling `RUN EXTENSION` button till the required fields are not filled.
* Fix dark mode failures in extension modal.