### PR TITLE
feat(empty-list-message): added error message for empty experiment list page

### DIFF
--- a/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
+++ b/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
@@ -49,7 +49,6 @@ const TagBox = styled(Box)`
 
 const NoExperimentsMessage = styled(Typography)`
   font-size: 0.95rem;
-  /* background-color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.common.black : theme.palette.common.white}; */
   color: ${({ theme }) => theme.palette.grey[500]};
   text-align: center;
   padding: ${(props) => `${props.theme.spacing(2.5)}`};

--- a/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
+++ b/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
@@ -203,6 +203,17 @@ function ExperimentRecordsPage({ category }: { category?: ExperimentRecordsPageT
     }
   };
 
+  const emptyListErrorMessage = (pageUrl: string) => {
+    switch(pageUrl) {
+      case "/aqd/experiments/favourites":
+        return "No favourited experiment records found";
+      case "/aqd/experiments/archived":
+        return "No archived experiment records found";
+      default:
+        return "No experiment records found";
+    }
+  }
+
   const handleResetPagination = () => {
     const newQueryParameters: URLSearchParams = new URLSearchParams(searchParams);
     newQueryParameters.set('rowsPerPage', String(rowsPerPage))
@@ -230,9 +241,9 @@ function ExperimentRecordsPage({ category }: { category?: ExperimentRecordsPageT
             pageInfo={pageInfo}
             maxHeight={`calc(100vh - ${tableHeightOffset}px)`}
           />
-        ) :
-        <NoExperimentsMessage>No experiments found.</NoExperimentsMessage>
-        }
+        ) : ""
+      }
+      {!loading && !pageInfo.count && <NoExperimentsMessage>{emptyListErrorMessage(location.pathname)}</NoExperimentsMessage>}
       </Box>
     </Container>
   );

--- a/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
+++ b/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
@@ -47,6 +47,14 @@ const TagBox = styled(Box)`
   margin-right: ${(props) => props.theme.spacing(1)};
 `;
 
+const NoExperimentsMessage = styled(Typography)`
+  font-size: 0.95rem;
+  /* background-color: ${({ theme }) => theme.palette.mode === "dark" ? theme.palette.common.black : theme.palette.common.white}; */
+  color: ${({ theme }) => theme.palette.grey[500]};
+  text-align: center;
+  padding: ${(props) => `${props.theme.spacing(2.5)}`};
+`;
+
 export const ExperimentRecordsColumns: readonly ExperimentRecordsColumnsType[] = [
   { id: "alias", label: "EID", minWidth: 170 },
   {
@@ -222,7 +230,9 @@ function ExperimentRecordsPage({ category }: { category?: ExperimentRecordsPageT
             pageInfo={pageInfo}
             maxHeight={`calc(100vh - ${tableHeightOffset}px)`}
           />
-        ) : null}
+        ) :
+        <NoExperimentsMessage>No experiments found.</NoExperimentsMessage>
+        }
       </Box>
     </Container>
   );

--- a/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
+++ b/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
@@ -240,8 +240,7 @@ function ExperimentRecordsPage({ category }: { category?: ExperimentRecordsPageT
             pageInfo={pageInfo}
             maxHeight={`calc(100vh - ${tableHeightOffset}px)`}
           />
-        ) : ""
-      }
+        ) : null}
       {!loading && !pageInfo.count && <NoExperimentsMessage>{emptyListErrorMessage(location.pathname)}</NoExperimentsMessage>}
       </Box>
     </Container>

--- a/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
+++ b/aqueductcore/frontend/src/pages/ExperimentRecordsPage/index.tsx
@@ -1,5 +1,5 @@
+import { LinearProgress, Typography, styled } from "@mui/material";
 import { useLocation, useSearchParams } from "react-router-dom";
-import { Typography, styled } from "@mui/material";
 import Box from "@mui/material/Box";
 import { useState } from "react";
 
@@ -229,19 +229,20 @@ function ExperimentRecordsPage({ category }: { category?: ExperimentRecordsPageT
       {/* //Guides would be added here */}
       <FilterExperiments filters={filters} setFilters={setFilters} handleResetPagination={handleResetPagination} />
       <Box sx={{ mt: 2 }}>
-        {processedExperimentData && pageInfo.count && !loading ? (
-          <ExperimentsListTable
-            ExperimentRecordsColumns={
-              location.pathname.includes("archived") || location.pathname.includes("favourite")
-                ? ExperimentRecordsColumns
-                : ExperimentRecordsColumnsWithFavColumn
-            }
-            experimentList={processedExperimentData}
-            pageInfo={pageInfo}
-            maxHeight={`calc(100vh - ${tableHeightOffset}px)`}
-          />
-        ) : null}
-      {!loading && !pageInfo.count && <NoExperimentsMessage>{emptyListErrorMessage(location.pathname)}</NoExperimentsMessage>}
+        {loading ? <LinearProgress /> :
+          processedExperimentData && pageInfo.count ? (
+            <ExperimentsListTable
+              ExperimentRecordsColumns={
+                location.pathname.includes("archived") || location.pathname.includes("favourite")
+                  ? ExperimentRecordsColumns
+                  : ExperimentRecordsColumnsWithFavColumn
+              }
+              experimentList={processedExperimentData}
+              pageInfo={pageInfo}
+              maxHeight={`calc(100vh - ${tableHeightOffset}px)`}
+            /> ) :
+            <NoExperimentsMessage>{emptyListErrorMessage(location.pathname)}</NoExperimentsMessage>
+        }
       </Box>
     </Container>
   );


### PR DESCRIPTION
## Changes
* added error message in the `recents`, `archived` and `favourites` pages in case of no experiments in the list.