### PR TITLE
fix(docker): Set the number of workers for release docker images to 4.

### DIFF
--- a/containers/release-azure/entrypoint.sh
+++ b/containers/release-azure/entrypoint.sh
@@ -5,4 +5,4 @@ service ssh start
 # Save all environment variables to /etc/environment for later use via SSH
 env | grep _ >> /etc/environment
 
-exec gunicorn -w 1 -k uvicorn.workers.UvicornWorker aqueductcore.backend.main:app --bind 0.0.0.0:8000 --timeout 60
+exec gunicorn -w 4 -k uvicorn.workers.UvicornWorker aqueductcore.backend.main:app --bind 0.0.0.0:8000 --timeout 60

--- a/containers/release/Dockerfile
+++ b/containers/release/Dockerfile
@@ -11,4 +11,4 @@ ADD frontend_build ./frontend_build
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir $(ls dist/*.whl)
 
-CMD ["gunicorn", "-w", "1", "-k", "uvicorn.workers.UvicornWorker", "aqueductcore.backend.main:app", "--bind", "0.0.0.0:8000", "--timeout", "60"]
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "aqueductcore.backend.main:app", "--bind", "0.0.0.0:8000", "--timeout", "60"]


### PR DESCRIPTION
This PR Set the number of workers for the release docker images to 4 to fix the issue with running extensions blocking the server thread from handling new requests. 