### PR TITLE
feat(data-persistence): Added data persistence on switching between different functions

### DIFF
--- a/aqueductcore/frontend/src/__tests__/Extensions.test.tsx
+++ b/aqueductcore/frontend/src/__tests__/Extensions.test.tsx
@@ -84,6 +84,42 @@ test("click the other action and params should be updated", async () => {
     }
 });
 
+test("data is persistence when switching between functions", async () => {
+
+    const { findByTitle, findByText } = render(<ExtensionIncludedComponent />)
+    const extensionOpenModalButton = await findByTitle("extensions")
+    await userEvent.click(extensionOpenModalButton)
+
+    const firstActionName = ExtensionsDataMock[0].actions[0].name
+    const secondActionName = ExtensionsDataMock[0].actions[1].name
+
+    const first_extension = await findByText(ExtensionsDataMock[0].name);
+    await userEvent.click(first_extension)
+
+    const firstInput = ExtensionsDataMock[0].actions[0].parameters[0].name;
+    const inputField = (await findByText(firstInput)).nextSibling?.firstChild?.firstChild?.firstChild;
+    expect(inputField).toBeInTheDocument();
+
+    if (!(inputField instanceof Element)) throw new Error("Input field is not an element");
+
+    await userEvent.clear(inputField);
+    await userEvent.type(inputField, '321');
+    expect(inputField).toHaveValue('321');
+
+    const secondActionButton = await findByText(secondActionName);
+    await userEvent.click(secondActionButton);
+
+    const secondActionFirstInput = await findByText(ExtensionsDataMock[0].actions[1].parameters[0].name);
+    expect(secondActionFirstInput).toBeInTheDocument();
+
+    const firstActionButton = await findByText(firstActionName);
+    await userEvent.click(firstActionButton);
+
+    const firstInputAfterUpdate = ExtensionsDataMock[0].actions[0].parameters[0].name;
+    const inputFieldAfterUpdate = (await findByText(firstInputAfterUpdate)).nextSibling?.firstChild?.firstChild?.firstChild;
+    expect(inputFieldAfterUpdate).toHaveValue('321');
+});
+
 test("submit the form and success modal and file selection", async () => {
 
     const { findByTitle, findByText, findAllByText } = render(<ExtensionIncludedComponent />)
@@ -106,3 +142,4 @@ test("submit the form and success modal and file selection", async () => {
     expect(file_name_items[1]).toHaveProperty('title', 'file_name')
 });
 
+// TODO: Fix needed to allow mote tests after this (file loading API will fail)

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -123,19 +123,6 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
     const { setSelectedFile } = useContext(FileSelectStateContext);
 
     useEffect(() => {
-        if (!isOpen) {
-            setFunctionFormData(prevState => {
-                Object.entries(prevState).forEach(([key]) => {
-                    prevState[key].forEach((item) => {
-                        item.value = selectedExtensionItem?.actions.find((action) => action.name === key)?.parameters.find((parameter) => parameter.name === item.name)?.defaultValue;
-                    })
-                })
-                return prevState;
-            })
-        }
-    }, [isOpen])
-
-    useEffect(() => {
         if (selectedAction && selectedExtension) {
             setFunctionFormData(prevState => {
                 if (!prevState[selectedAction.name]) {
@@ -158,7 +145,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
         && functionFormData[selectedAction.name].every(param => param.value);
 
     async function handleOnCompletedExtensionExecution(executeExtension: EXECUTE_EXTENSION_TYPE) {
-        handleClose()
+        handleCloseModal()
         await client.refetchQueries({
             include: "active",
         });
@@ -189,6 +176,22 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
         }
     }
 
+    function handleCloseModal() {
+        handleClose()
+        resetExtensionForm()
+    }
+
+    function resetExtensionForm() {
+        setFunctionFormData(prevState => {
+            Object.entries(prevState).forEach(([key]) => {
+                prevState[key].forEach((item) => {
+                    item.value = selectedExtensionItem?.actions.find((action) => action.name === key)?.parameters.find((parameter) => parameter.name === item.name)?.defaultValue;
+                })
+            })
+            return prevState;
+        })
+    }
+
     const updateSelectedActionHandler = (option: string) => {
         setSelectedAction(selectedExtensionItem?.actions.find(item => item.name === option));
     };
@@ -201,14 +204,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
     };
 
     return (
-        <Modal
-            open={isOpen}
-            onClose={(event, reason) => {
-                if (reason !== 'backdropClick') {
-                    handleClose();
-                }
-            }}
-        >
+        <Modal open={isOpen}>
             <ModalContainer>
                 <form onSubmit={handleExecuteExtension}>
                     <ModalHeader
@@ -224,7 +220,7 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
                             <ExtensionName>{selectedExtension}</ExtensionName>
                         </Grid>
                         <Grid item>
-                            <CloseIcon onClick={handleClose} sx={{ cursor: "pointer", lineHeight: "3.313rem", verticalAlign: "middle" }} />
+                            <CloseIcon onClick={handleCloseModal} sx={{ cursor: "pointer", lineHeight: "3.313rem", verticalAlign: "middle" }} />
                         </Grid>
                     </ModalHeader>
                     <ModalMain container>

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -210,53 +210,55 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
             }}
         >
             <ModalContainer>
-                <ModalHeader
-                    container
-                    sx={{
-                        justifyContent: "space-between"
-                    }}
-                >
-                    <Grid item>
-                        <HeaderIcon />
-                        <AuthorName>{selectedExtensionItem?.authors}</AuthorName>
-                        <HeaderRightIcon />
-                        <ExtensionName>{selectedExtension}</ExtensionName>
-                    </Grid>
-                    <Grid item>
-                        <CloseIcon onClick={handleClose} sx={{ cursor: "pointer", lineHeight: "3.313rem", verticalAlign: "middle" }} />
-                    </Grid>
-                </ModalHeader>
-                <ModalMain container>
-                    <ModalOptionsGrid item xs={4}>
-                        {/* left-side: Actions */}
-                        {selectedExtensionItem?.actions.length ?
-                            <ExtensionActions
-                                extension={selectedExtensionItem}
-                                selectedAction={selectedAction}
-                                updateSelectedAction={updateSelectedActionHandler}
-                            /> : null}
-                    </ModalOptionsGrid>
-                    <ModalInputsGrid item xs={8}>
-                        {/* right-side: Inputs */}
-                        {selectedAction && functionFormData[selectedAction.name] ?
-                            <ActionForm
-                                selectedAction={selectedAction}
-                                inputParams={functionFormData[selectedAction.name]}
-                                setInputParams={(params) => updateFormData(selectedAction.name, params)}
-                            /> : null}
-                    </ModalInputsGrid>
-                </ModalMain>
-                <ModalFooter>
-                    {loading ? <CircularProgress size={36} sx={{ mr: 3 }} /> : null}
-                    <RunExtension
-                        variant="contained"
-                        onClick={() => handleExecuteExtension()}
-                        title='run_extension'
-                        disabled={!isExtensionExecutable}
+                <form onSubmit={handleExecuteExtension}>
+                    <ModalHeader
+                        container
+                        sx={{
+                            justifyContent: "space-between"
+                        }}
                     >
-                        Run Extension
-                    </RunExtension>
-                </ModalFooter>
+                        <Grid item>
+                            <HeaderIcon />
+                            <AuthorName>{selectedExtensionItem?.authors}</AuthorName>
+                            <HeaderRightIcon />
+                            <ExtensionName>{selectedExtension}</ExtensionName>
+                        </Grid>
+                        <Grid item>
+                            <CloseIcon onClick={handleClose} sx={{ cursor: "pointer", lineHeight: "3.313rem", verticalAlign: "middle" }} />
+                        </Grid>
+                    </ModalHeader>
+                    <ModalMain container>
+                        <ModalOptionsGrid item xs={4}>
+                            {/* left-side: Actions */}
+                            {selectedExtensionItem?.actions.length ?
+                                <ExtensionActions
+                                    extension={selectedExtensionItem}
+                                    selectedAction={selectedAction}
+                                    updateSelectedAction={updateSelectedActionHandler}
+                                /> : null}
+                        </ModalOptionsGrid>
+                        <ModalInputsGrid item xs={8}>
+                            {/* right-side: Inputs */}
+                            {selectedAction && functionFormData[selectedAction.name] ?
+                                <ActionForm
+                                    selectedAction={selectedAction}
+                                    inputParams={functionFormData[selectedAction.name]}
+                                    setInputParams={(params) => updateFormData(selectedAction.name, params)}
+                                /> : null}
+                        </ModalInputsGrid>
+                    </ModalMain>
+                    <ModalFooter>
+                        {loading ? <CircularProgress size={36} sx={{ mr: 3 }} /> : null}
+                        <RunExtension
+                            type="submit"
+                            variant="contained"
+                            title='run_extension'
+                            disabled={!isExtensionExecutable}
+                        >
+                            Run Extension
+                        </RunExtension>
+                    </ModalFooter>
+                </form>
             </ModalContainer>
         </Modal >
     )

--- a/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
+++ b/aqueductcore/frontend/src/components/organisms/ExtensionModal/index.tsx
@@ -123,6 +123,19 @@ function ExtensionModal({ isOpen, handleClose, selectedExtension }: ExtensionMod
     const { setSelectedFile } = useContext(FileSelectStateContext);
 
     useEffect(() => {
+        if (!isOpen) {
+            setFunctionFormData(prevState => {
+                Object.entries(prevState).forEach(([key]) => {
+                    prevState[key].forEach((item) => {
+                        item.value = selectedExtensionItem?.actions.find((action) => action.name === key)?.parameters.find((parameter) => parameter.name === item.name)?.defaultValue;
+                    })
+                })
+                return prevState;
+            })
+        }
+    }, [isOpen])
+
+    useEffect(() => {
         if (selectedAction && selectedExtension) {
             setFunctionFormData(prevState => {
                 if (!prevState[selectedAction.name]) {

--- a/aqueductcore/frontend/src/types/componentTypes.ts
+++ b/aqueductcore/frontend/src/types/componentTypes.ts
@@ -10,6 +10,10 @@ export type selectedFileType = ExperimentFileType['modifiedAt'] | undefined
 
 export type actionInExtensionsType = { name: string, value?: string | null }
 
+export type extensionActionsData = {
+    [key: string]: actionInExtensionsType[]
+}
+
 export type FileSelectContextType = {
     selectedFile: string | undefined,
     setSelectedFile: React.Dispatch<React.SetStateAction<string | undefined>>

--- a/containers/dev/docker-compose.yaml
+++ b/containers/dev/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
   postgres:
     image: postgres:15-alpine
     restart: unless-stopped
+    platform: linux/amd64
     environment:
       - POSTGRES_USER=aqueductcore
       - POSTGRES_PASSWORD=password

--- a/containers/dev/docker-compose.yaml
+++ b/containers/dev/docker-compose.yaml
@@ -23,7 +23,6 @@ services:
   postgres:
     image: postgres:15-alpine
     restart: unless-stopped
-    platform: linux/amd64
     environment:
       - POSTGRES_USER=aqueductcore
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
## Changes
* extension modal submit button now functions as a form
* add test for data persistence

## Features covered
* Keep the data while changing between actions(FKA functions)
* On successful execution of the function form data should be cleared
* It should be a Form with onSubmit and pressing enter as a submission