### PR TITLE
fix(docker): Update reference release docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can find `docker-compose.yaml` file under `aqueductcore/scripts/release` dir
 
 3. Start your browser and point it to `https://localhost`.
 
-For more information please check the [documentation](https://aqueducthub.github.io/aqueductcore/).
+A reference docker compose file for installation in the production environment is provided in [scripts/release/docker-compose.yaml](scripts/release/docker-compose.yaml). For more information please check the [documentation](https://aqueducthub.github.io/aqueductcore/).
 
 #### Development Docker Images
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,1 @@
+This directory contains the reference docker compose file that can be used to install the release versions of Aqueduct.

--- a/scripts/release/docker-compose.yaml
+++ b/scripts/release/docker-compose.yaml
@@ -1,26 +1,58 @@
-version: '3'
+version: "3"
+
+x-aqueduct-common: &aqueduct-common
+  platform: linux/amd64
+  image: aqueducthub/aqueductcore-dev:latest
+  restart: always
+  depends_on:
+    - postgres
+    - rabbitmq
+  environment:
+    EXPERIMENTS_DIR_PATH: /tmp/aqueduct_experiments
+    EXTENSIONS_DIR_PATH: /workspace/external/extensions
+    POSTGRES_USERNAME: admin
+    POSTGRES_PASSWORD: admin
+    POSTGRES_HOST: postgres
+    POSTGRES_PORT: 5432
+    POSTGRES_DB: aqueduct
+    CELERY_MESSAGE_QUEUE: amqp://guest:guest@rabbitmq:5672
+  volumes:
+    - ${EXPERIMENTS_DIR}:/tmp/aqueduct_experiments
+    - ${EXTENSIONS_DIR}:/workspace/external/extensions
+
 services:
   aqueduct:
-    platform: linux/amd64
-    image: aqueducthub/aqueductcore:latest
-    restart: always
-    depends_on:
-      - postgres
-    environment:
-      EXPERIMENTS_DIR_PATH: /tmp/aqueduct_experiments
-      EXTENSIONS_DIR_PATH: /workspace/external/extensions
-      POSTGRES_USERNAME: admin
-      POSTGRES_PASSWORD: admin
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_DB: aqueduct
-    volumes:
-      - ${EXPERIMENTS_DIR}:/tmp/aqueduct_experiments
-      - type: bind
-        source: ${EXTENSIONS_DIR}
-        target: /workspace/external/extensions
+    <<: *aqueduct-common
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.aqueduct.rule=Host(`aqueduct.localhost`)"
+    expose:
+      - 8000
+
+  aqueduct-worker:
+    <<: *aqueduct-common
+    labels:
+      - "traefik.enable=false"
+    command: aqueduct worker
+
+  aqueduct-flower:
+    <<: *aqueduct-common
+    command: aqueduct flower --broker-api http://guest:guest@rabbitmq:15672/api/vhost
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.aqueduct-flower.rule=Host(`flower.localhost`)"
     ports:
-      - 80:8000
+      - 5555
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.rabbitmq.rule=Host(`rabbitmq.localhost`)"
+      - "traefik.http.services.rabbitmq.loadbalancer.server.port=15672"
+    expose:
+      - 5672
+      - 15672
 
   postgres:
     platform: linux/amd64
@@ -30,5 +62,16 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin
       - POSTGRES_DB=aqueduct
+    labels:
+      - "traefik.enable=false"
     expose:
       - 5432
+
+  reverse-proxy:
+    image: traefik:v3.1
+    command: --api.insecure=true --providers.docker
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -11,7 +11,4 @@ export EXTENSIONS_DIR=$HOME/external/extensions
 mkdir -p $EXPERIMENTS_DIR
 mkdir -p $EXTENSIONS_DIR
 
-# load Aqueduct docker image
-docker load -i $SCRIPT_DIR/aqueductcore.tar
-
 docker compose -f $SCRIPT_DIR/docker-compose.yaml up -d


### PR DESCRIPTION
This PR updates the reference docker-compose to add celery worker and flower alongside rabbitmq. Traefik reverse proxy is also added to let the user access different services via the host address `*.localhost`. Traefik automatically handles this DNS addition to the host, which I found very interesting! We might later change it but it is a good starting point.