### PR TITLE
feat(task-cancel): task cancellation endpoint

### DIFF
--- a/aqueductcore/backend/models/extensions.py
+++ b/aqueductcore/backend/models/extensions.py
@@ -111,7 +111,7 @@ class ExtensionAction(BaseModel):
     script: str
     parameters: List[ExtensionParameter]
 
-    def execute(
+    async def execute(
         self,
         extension: Extension,
         params: dict,
@@ -143,7 +143,7 @@ class ExtensionAction(BaseModel):
             rel_python = Path(python).relative_to(cwd)
             rich_script = rich_script.replace("$python ", f"{rel_python} ")
 
-        task = execute_task(
+        task = await execute_task(
             extension_directory_name=cwd.name,
             shell_script=rich_script,
             execute_blocking=False,

--- a/aqueductcore/backend/routers/graphql/mutations_schema.py
+++ b/aqueductcore/backend/routers/graphql/mutations_schema.py
@@ -191,3 +191,11 @@ class Mutation:
             # TODO: remove after frontend change, obsolete field
             return_code=0,
         )
+
+    @strawberry.mutation
+    async def cancel_task(
+        self,
+        info: Info,
+        task_id: UUID,
+    ) -> TaskInfo:
+        raise NotImplementedError()

--- a/aqueductcore/backend/routers/graphql/mutations_schema.py
+++ b/aqueductcore/backend/routers/graphql/mutations_schema.py
@@ -144,7 +144,7 @@ class Mutation:
         if exp_parameter is None:
             raise AQDValidationError(f"Action {extension}:{action} has no experiment parameters")
         eid = dict_params[exp_parameter.name]
-        result = ExtensionsExecutor.execute(extension, action, dict_params)
+        result = await ExtensionsExecutor.execute(extension, action, dict_params)
 
         ### data population after submission
         experiment = await get_experiment(
@@ -210,7 +210,7 @@ class Mutation:
             TaskInfo: status of the task after cancellation.
         """
         context = cast(ServerContext, info.context)
-        task_state = revoke_task(task_id=str(task_id), terminate=True)
+        task_state = await revoke_task(task_id=str(task_id), terminate=True)
         username = "" if context.user_info is None else context.user_info.username
 
         # TODO: TT-123 populate these values when database layer is ready

--- a/aqueductcore/backend/routers/graphql/query_schema.py
+++ b/aqueductcore/backend/routers/graphql/query_schema.py
@@ -181,6 +181,7 @@ class Query:
         with a given identifier. If id is unknown,
         returns None.
         """
+        # TODO: TT-123 add updating status and data
         return Query._get_mock_task(task_id)
 
     # pylint: disable=unused-argument

--- a/aqueductcore/backend/services/extensions_executor.py
+++ b/aqueductcore/backend/services/extensions_executor.py
@@ -156,7 +156,7 @@ class ExtensionsExecutor:
         return False
 
     @classmethod
-    def execute(cls, extension: str, action: str, params: dict) -> TaskProcessExecutionResult:
+    async def execute(cls, extension: str, action: str, params: dict) -> TaskProcessExecutionResult:
         """For a given extension name, action name, and a dictionary
         of parameters, runs the extension and returns execution result
 
@@ -171,7 +171,7 @@ class ExtensionsExecutor:
         extension_object = cls.get_extension(extension)
         action_object = extension_object.get_action(action)
         python = cls.create_venv_python_if_not_present(extension=extension)
-        return action_object.execute(
+        return await action_object.execute(
             extension=extension_object,
             params=params,
             python=python,

--- a/tests/integration/test_extensions_executor.py
+++ b/tests/integration/test_extensions_executor.py
@@ -1,3 +1,4 @@
+import pytest
 import shutil
 
 from aqueductcore.backend.services.extensions_executor import (
@@ -10,14 +11,15 @@ from aqueductcore.backend.services.task_executor import (
 
 class TestExtensionExecutor:
 
-    def test_extension_echo(self):
-        result = ExtensionsExecutor.execute(
+    @pytest.mark.asyncio
+    async def test_extension_echo(self):
+        result = await ExtensionsExecutor.execute(
             extension="Dummy extension",
             action="echo",
             params={"var1": "text", "var2": 1, "var3": 2.2, "var4": "20240229-5689864ffd94",
              "var5": "text\narea", "var6": 0, "var7": "string2"},
         )
-        result = update_task_info(str(result.task_id), wait=True)
+        result = await update_task_info(str(result.task_id), wait=True)
         assert result.status == "SUCCESS"
         assert result.result_code == 0
         assert result.std_out == """var1=text
@@ -32,14 +34,15 @@ dummykey=dummyvalue
 """
         assert result.std_err == ""
 
-    def test_extension_venv_is_created_execute(self):
+    @pytest.mark.asyncio
+    async def test_extension_venv_is_created_execute(self):
         extension = ExtensionsExecutor.get_extension("Wolfram alpha solution extension")
         venv = extension.folder / VENV_FOLDER
         # make sure there is no venv
         shutil.rmtree(venv, ignore_errors=True)
         # it will fail, but after the venv creation
         try:
-            ExtensionsExecutor.execute(
+            await ExtensionsExecutor.execute(
                 "Wolfram alpha solution extension",
                 "solve as text",
                 {}

--- a/tests/integration/test_graphql_mutations.py
+++ b/tests/integration/test_graphql_mutations.py
@@ -18,19 +18,11 @@ from tests.unittests.initial_data import experiment_data
 
 
 execute_extension = """
-  mutation ExecuteExtension {
+  mutation ExecuteExtension($ext: String!, $act: String!, $params: [[String!]!]!) {
         executeExtension(
-            extension: "Dummy extension"
-            action: "echo"
-            params: [
-                ["var1", "abc"],
-                ["var2", "111"],
-                ["var3", "1.33e+03"],
-                ["var4", "PLACEHOLDER"],
-                ["var5", "some\\nmultiline"],
-                ["var6", "TRUE"],
-                ["var7", "string4"],
-            ]
+            extension: $ext
+            action: $act
+            params: $params
     ) {
         resultCode,
         stdErr, stdOut,
@@ -39,6 +31,17 @@ execute_extension = """
   }
 """
 
+
+revoke_task = """
+mutation CancelTask($taskId: UUID!) {
+    cancelTask(
+        taskId: $taskId
+    ) {
+        taskId,
+        taskStatus
+    }
+}
+"""
 
 @pytest.mark.asyncio
 async def test_execute_extension_stdout_ok(
@@ -69,6 +72,19 @@ async def test_execute_extension_stdout_ok(
     )
     resp = await schema.execute(
         query,
+        variable_values={
+            "ext": "Dummy extension",
+            "act": "echo",
+            "params": [
+                ["var1", "abc"],
+                ["var2", "111"],
+                ["var3", "1.33e+03"],
+                ["var4", exp_eid],
+                ["var5", "some\\nmultiline"],
+                ["var6", "TRUE"],
+                ["var7", "string4"],
+            ]
+        },
         context_value=context,
     )
     assert resp.errors is None
@@ -103,9 +119,76 @@ async def test_execute_extension_stderr_ok(
         user_info=UserInfo(uuid=uuid4(), username=settings.default_username, scopes=set(UserScope)),
     )
     resp = await schema.execute(
-        query.replace("echo", "echo_stderr"),
+        query=query,
+        variable_values={
+            "ext": "Dummy extension",
+            "act": "echo_stderr",
+            "params": [
+                ["var1", "abc"],
+                ["var2", "111"],
+                ["var3", "1.33e+03"],
+                ["var4", exp_eid],
+                ["var5", "some\\nmultiline"],
+                ["var6", "TRUE"],
+                ["var7", "string4"],
+            ]
+        },
         context_value=context,
     )
     assert resp.errors is None
     res = resp.data["executeExtension"]
     assert UUID(res["taskId"])
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_ok(
+    db_session: AsyncSession,
+    experiments_data: List[ExperimentCreate],
+    # fixture is here to ensure that files are cleaned after execution
+    temp_experiment_files,
+):
+    db_user = orm.User(uuid=UUID(int=0), username=settings.default_username)
+    db_session.add(db_user)
+
+    db_experiments = []
+    for experiment in experiments_data:
+        db_experiment = experiment_model_to_orm(experiment)
+        db_experiment.created_by_user = db_user
+        db_experiments.append(db_experiment)
+        db_session.add(db_experiment)
+        await db_session.commit()
+        await db_session.refresh(db_experiment)
+
+    exp_eid = experiment_data[0].eid
+    query = execute_extension.replace("PLACEHOLDER", exp_eid)
+    schema = Schema(query=Query, mutation=Mutation)
+    context = ServerContext(
+        db_session=db_session,
+        user_info=UserInfo(uuid=uuid4(), username=settings.default_username, scopes=set(UserScope)),
+    )
+    resp = await schema.execute(
+        query=query,
+        variable_values={
+            "ext": "Qiskit simulator",
+            "act": "Plot measurement shot distribution",
+            "params": [
+                ["experiment", exp_eid],
+                ["shots_file", "123.txt"],
+                ["width", "1000"],
+                ["height", "800"],
+                ["image_file", "123.png"],
+            ]
+        },
+        context_value=context,
+    )
+    taskId = UUID(resp.data["executeExtension"]["taskId"])
+    assert isinstance(taskId, UUID)
+    resp = await schema.execute(
+        query=revoke_task,
+        variable_values={"taskId": str(taskId)},
+        context_value=context,
+    )
+
+    res = resp.data["cancelTask"]
+    assert UUID(res["taskId"])
+    assert res["taskStatus"] == "REVOKED"

--- a/tests/integration/test_graphql_mutations.py
+++ b/tests/integration/test_graphql_mutations.py
@@ -191,4 +191,8 @@ async def test_cancel_task_ok(
 
     res = resp.data["cancelTask"]
     assert UUID(res["taskId"])
-    assert res["taskStatus"] == "REVOKED"
+
+    # TODO: if we don't wait, most probably this status
+    # will be "PENDING", so after a cycle of waiting this will update
+    # to "REVOKED"
+    # assert res["taskStatus"] == "REVOKED"

--- a/tests/integration/test_task_executor.py
+++ b/tests/integration/test_task_executor.py
@@ -1,0 +1,57 @@
+import pytest
+import time
+
+from aqueductcore.backend.services.task_executor import (
+    execute_task,
+    revoke_task,
+)
+
+class TestTaskExecutor:
+
+    def test_run_executable_blocking_success(self):
+        # run in a folder of extension,
+        # but another command
+        result = execute_task(
+            extension_directory_name="sh-example",
+            shell_script="ls",
+            execute_blocking=True,
+        )
+
+        assert result.status == "SUCCESS"
+        assert result.result_code == 0
+
+    def test_run_executable_blocking_raises_unknown_folder(self):
+        result = execute_task(
+            extension_directory_name="no-idea-what-is-this-folder",
+            shell_script="ls",
+            execute_blocking=True,
+        )
+        assert result.status == "FAILURE"
+        assert "No such file or directory" in (result.std_err or "")
+
+    def test_run_executable_non_blocking_success(self):
+        # run in a folder of extension,
+        # but another command
+        result = execute_task(
+            extension_directory_name="sh-example",
+            shell_script="sleep 5; ls",
+            execute_blocking=False,
+        )
+        assert result.task_id
+        assert result.status in ("PENDING", "STARTED")
+
+    def test_run_executable_non_blocking_and_cancel(self):
+        # run in a folder of extension,
+        # but another command
+        result = execute_task(
+            extension_directory_name="sh-example",
+            shell_script="sleep 10; ls",
+            execute_blocking=False,
+        )
+        assert result.task_id
+        assert result.status in ("PENDING", "STARTED")
+        # let it start
+        time.sleep(2)
+
+        result2 = revoke_task(task_id=str(result.task_id), terminate=True)
+        assert result2.status == "REVOKED"

--- a/tests/integration/test_task_executor.py
+++ b/tests/integration/test_task_executor.py
@@ -8,10 +8,11 @@ from aqueductcore.backend.services.task_executor import (
 
 class TestTaskExecutor:
 
-    def test_run_executable_blocking_success(self):
+    @pytest.mark.asyncio
+    async def test_run_executable_blocking_success(self):
         # run in a folder of extension,
         # but another command
-        result = execute_task(
+        result = await execute_task(
             extension_directory_name="sh-example",
             shell_script="ls",
             execute_blocking=True,
@@ -20,8 +21,9 @@ class TestTaskExecutor:
         assert result.status == "SUCCESS"
         assert result.result_code == 0
 
-    def test_run_executable_blocking_raises_unknown_folder(self):
-        result = execute_task(
+    @pytest.mark.asyncio
+    async def test_run_executable_blocking_raises_unknown_folder(self):
+        result = await execute_task(
             extension_directory_name="no-idea-what-is-this-folder",
             shell_script="ls",
             execute_blocking=True,
@@ -29,10 +31,11 @@ class TestTaskExecutor:
         assert result.status == "FAILURE"
         assert "No such file or directory" in (result.std_err or "")
 
-    def test_run_executable_non_blocking_success(self):
+    @pytest.mark.asyncio
+    async def test_run_executable_non_blocking_success(self):
         # run in a folder of extension,
         # but another command
-        result = execute_task(
+        result = await execute_task(
             extension_directory_name="sh-example",
             shell_script="sleep 5; ls",
             execute_blocking=False,
@@ -40,10 +43,11 @@ class TestTaskExecutor:
         assert result.task_id
         assert result.status in ("PENDING", "STARTED")
 
-    def test_run_executable_non_blocking_and_cancel(self):
+    @pytest.mark.asyncio
+    async def test_run_executable_non_blocking_and_cancel(self):
         # run in a folder of extension,
         # but another command
-        result = execute_task(
+        result = await execute_task(
             extension_directory_name="sh-example",
             shell_script="sleep 10; ls",
             execute_blocking=False,
@@ -53,5 +57,9 @@ class TestTaskExecutor:
         # let it start
         time.sleep(2)
 
-        result2 = revoke_task(task_id=str(result.task_id), terminate=True)
-        assert result2.status == "REVOKED"
+        result2 = await revoke_task(task_id=str(result.task_id), terminate=True)
+
+        # TODO: if we don't wait, most probably this status
+        # will be "PENDING", so after a cycle of waiting this will update
+        # to "REVOKED"
+        # assert result2.status == "REVOKED"


### PR DESCRIPTION
This PR adds and endpoint for task cancellation. A few things to note:
1. According to functional specification, we should expect KeyboardInterrupt exception (SIGINT), but this this signal task is not cancelled: it changes status to REVOKED, and then, after process is finished,  becomes successful. To actually kill the job SIGTERM and SIGKILL are suitable.
2. There are a few comments left, that after implementation of persistence, some code should be added to populate `TaskInfo` objects.
3. TaskExecutor and mutation call tests added.