### PR TITLE
fix(failing-automated-release): update checkout action version and update secret variable name

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -37,9 +37,9 @@ jobs:
       name: automated-release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACTIONS_TOKEN }}
 
       - name: Get current release version and calculate next patch version
         id: next_version_step


### PR DESCRIPTION
## Changes
* Update checkout action version from Github marketplace
* Use secrets.ACTIONS_TOKEN in `automated_release.yaml`