### PR TITLE
fix(cancellation): adding failure processing

### DIFF
--- a/aqueductcore/backend/services/task_executor.py
+++ b/aqueductcore/backend/services/task_executor.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from celery import Celery
 from celery.backends.base import TaskRevokedError
 from celery.result import AsyncResult
-from celery.states import FAILURE, SUCCESS
 from pydantic import ConfigDict, validate_call
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
If extension process has a return code != 0, raise a `ChildProcessError` and then handle this at the `update_task_info` level. Treat arguments of exception as result.